### PR TITLE
feat(types): improve paginate type inference and safety

### DIFF
--- a/src/Automate.ts
+++ b/src/Automate.ts
@@ -73,11 +73,11 @@ export default class Automate {
    *
    * ```
    */
-  paginate: (
-    apiMethod: PaginationApiMethod,
+  paginate: <T, Args extends unknown[]>(
+    apiMethod: PaginationApiMethod<T, Args>,
     paginateArgs: PaginationOptions,
-    ...methodArgs: Record<string, unknown>[]
-  ) => Promise<unknown[]>
+    ...methodArgs: Args
+  ) => Promise<T[]>
 
   constructor({
     serverUrl,

--- a/src/BaseAPI.ts
+++ b/src/BaseAPI.ts
@@ -159,8 +159,9 @@ export interface PaginationConfig {
   thisObj: InstanceType<typeof Automate | typeof Manage>
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-export type PaginationApiMethod = Function
+export type PaginationApiMethod<T = unknown, Args extends unknown[] = unknown[]> = (
+  ...args: Args
+) => Promise<T[]>
 
 export type PaginationOptions = {
   pageSize?: number
@@ -173,14 +174,14 @@ export type PaginationOptions = {
  */
 export const makePaginate =
   ({ thisObj }: PaginationConfig) =>
-  async (
-    apiMethod: PaginationApiMethod,
+  async <T, Args extends unknown[]>(
+    apiMethod: PaginationApiMethod<T, Args>,
     paginateArgs: PaginationOptions = {},
-    ...methodArgs: Record<string, unknown>[]
-  ): Promise<unknown[]> => {
+    ...methodArgs: Args
+  ): Promise<T[]> => {
     const { startPage = 1, pageSize = 1000 } = paginateArgs
 
-    let results: unknown[] = []
+    let results: T[] = []
     let page = startPage
 
     if (startPage === undefined || startPage < 1) {
@@ -208,29 +209,31 @@ export const makePaginate =
 /**
  * @internal
  */
-function getPage(
-  apiMethod: PaginationApiMethod,
-  methodArgs: Record<string, unknown>[],
+function getPage<T, Args extends unknown[]>(
+  apiMethod: PaginationApiMethod<T, Args>,
+  methodArgs: Args,
   thisObj: InstanceType<typeof Automate | typeof Manage>,
   page = 1,
   pageSize = 1000,
-): Promise<unknown[]> {
+): Promise<T[]> {
+  const args = [...methodArgs] as unknown[]
+
   // Javascript Function.length returns number of non-default values
   // the method args will always be greater than the api method args
   // due to this, if params is not passed in, even as an empty object,
   // we need to throw an error
-  if (methodArgs.length < apiMethod.length) {
+  if (args.length < apiMethod.length) {
     throw new Error(
       `CommonParams must be passed in for pagination to work properly for function ${apiMethod.name}`,
     )
   }
 
   // look for CommonParams and inject page and pageSize
-  const commonParams = <CommonParameters>methodArgs.pop()
+  const commonParams = args.pop() as CommonParameters
   commonParams.page = page
   commonParams.pageSize = pageSize
 
-  methodArgs.push(commonParams)
+  args.push(commonParams)
 
-  return apiMethod.apply(thisObj, methodArgs)
+  return apiMethod.apply(thisObj, args as Args)
 }

--- a/src/Manage.ts
+++ b/src/Manage.ts
@@ -87,11 +87,11 @@ export default class Manage {
    *
    * ```
    */
-  paginate: (
-    apiMethod: PaginationApiMethod,
+  paginate: <T, Args extends unknown[]>(
+    apiMethod: PaginationApiMethod<T, Args>,
     paginateArgs: PaginationOptions,
-    ...methodArgs: Record<string, unknown>[]
-  ) => Promise<unknown[]>
+    ...methodArgs: Args
+  ) => Promise<T[]>
 
   constructor({
     companyId,

--- a/test/pagination-types.ts
+++ b/test/pagination-types.ts
@@ -1,0 +1,15 @@
+import { expectTypeOf } from 'expect-type'
+import type Manage from '../src/Manage'
+
+type Ticket = { id: number; summary: string }
+type TicketParams = { conditions?: string; page?: number; pageSize?: number }
+
+declare const paginate: Manage['paginate']
+declare const getTickets: (params: TicketParams) => Promise<Ticket[]>
+
+const tickets = paginate(getTickets, { pageSize: 100 }, { conditions: 'closedFlag = false' })
+
+expectTypeOf(tickets).toEqualTypeOf<Promise<Ticket[]>>()
+
+// @ts-expect-error paginate should preserve the API method argument types.
+paginate(getTickets, { pageSize: 100 }, { invalid: true })

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -4,7 +4,7 @@
   "exclude": [],
   "compilerOptions": {
     "noEmit": true,
-    "rootDir": ".",
+    "rootDir": "..",
     "allowJs": true,
     "checkJs": false,
     "baseUrl": "."


### PR DESCRIPTION
# Changes
- Updates Automate.paginate and Manage.paginate to preserve the API method’s argument and return types.
- Replaces the broad Function-based PaginationApiMethod type with a generic function signature.
- Updates pagination internals so makePaginate and getPage return typed arrays instead of unknown[].
- Adds a type test verifying:
- paginate returns Promise<T[]> based on the API method result type.
- invalid method arguments are rejected by TypeScript.
- Adjusts the test tsconfig rootDir so the new type test can reference source files correctly.

# Why
Previously, paginate erased method-specific types, returning Promise<unknown[]> and accepting loosely typed arguments. This made pagination harder to use safely and weakened editor/type-checking support.
This change keeps pagination behavior the same at runtime while making TypeScript catch invalid usage earlier.