### PR TITLE
fix(types): improve PatchOperation specificity

### DIFF
--- a/generator/manage-generator.js
+++ b/generator/manage-generator.js
@@ -9,6 +9,7 @@
 
 const fs = require('fs')
 const path = require('path')
+const { factory, SyntaxKind } = require('typescript')
 const { ESLint } = require('eslint')
 const { generateAPIClass } = require('./generator.js')
 
@@ -22,6 +23,40 @@ function pascal(str) {
   return str.charAt(0).toUpperCase() + str.slice(1)
 }
 
+function createProperty(name, type, optional = false) {
+  return factory.createPropertySignature(
+    undefined,
+    factory.createIdentifier(name),
+    optional ? factory.createToken(SyntaxKind.QuestionToken) : undefined,
+    type,
+  )
+}
+
+function createOpType(...ops) {
+  return factory.createUnionTypeNode(
+    ops.map((op) => factory.createLiteralTypeNode(factory.createStringLiteral(op))),
+  )
+}
+
+function createPatchOperationTransform(_schemaObject, meta) {
+  if (meta.path !== '#/components/schemas/PatchOperation') {
+    return undefined
+  }
+
+  return factory.createUnionTypeNode([
+    factory.createTypeLiteralNode([
+      createProperty('op', createOpType('add', 'replace')),
+      createProperty('path', factory.createKeywordTypeNode(SyntaxKind.StringKeyword)),
+      createProperty('value', factory.createKeywordTypeNode(SyntaxKind.UnknownKeyword)),
+    ]),
+    factory.createTypeLiteralNode([
+      createProperty('op', createOpType('remove')),
+      createProperty('path', factory.createKeywordTypeNode(SyntaxKind.StringKeyword)),
+      createProperty('value', factory.createKeywordTypeNode(SyntaxKind.UnknownKeyword), true),
+    ]),
+  ])
+}
+
 async function emitTypes(spec) {
   console.log('generating ManageTypes.ts from spec')
   // openapi-typescript v7 is ESM-only; use dynamic import from this CJS script.
@@ -29,7 +64,7 @@ async function emitTypes(spec) {
   const openapiTS = mod.default ?? mod
   // v7 returns an AST (array of ts.Node); we must format via astToString.
   // v6 returns a string. Handle both.
-  const result = await openapiTS(spec)
+  const result = await openapiTS(spec, { transform: createPatchOperationTransform })
   let output
   if (typeof result === 'string') {
     output = result
@@ -100,17 +135,14 @@ import Manage from './Manage'
 import { CWLogger, RetryOptions } from './types'
 ${imports}
 
+import type { components } from './ManageTypes'
 ${typeExports}
 
 /**
  * @public
  * Manage patch operation input object, usually passed in an array of operations
  */
-export type PatchOperation = {
-  op: 'add' | 'replace' | 'remove'
-  path: string
-  value: unknown
-}
+export type PatchOperation = components['schemas']['PatchOperation']
 
 /**
  * @public

--- a/src/ManageAPI.ts
+++ b/src/ManageAPI.ts
@@ -14,6 +14,7 @@ import { ServiceAPI } from './Manage/ServiceAPI'
 import { SystemAPI } from './Manage/SystemAPI'
 import { TimeAPI } from './Manage/TimeAPI'
 
+import type { components } from './ManageTypes'
 import type * as CompanyAPITypes from './Manage/CompanyAPI'
 import type * as ConfigurationsAPITypes from './Manage/ConfigurationsAPI'
 import type * as ExpenseAPITypes from './Manage/ExpenseAPI'
@@ -31,11 +32,7 @@ import type * as TimeAPITypes from './Manage/TimeAPI'
  * @public
  * Manage patch operation input object, usually passed in an array of operations
  */
-export type PatchOperation = {
-  op: 'add' | 'replace' | 'remove'
-  path: string
-  value: unknown
-}
+export type PatchOperation = components['schemas']['PatchOperation']
 
 /**
  * @public

--- a/src/ManageTypes.ts
+++ b/src/ManageTypes.ts
@@ -41977,9 +41977,13 @@ export interface components {
             };
         };
         PatchOperation: {
-            op?: string;
-            path?: string;
-            value?: Record<string, never>;
+            op: "add" | "replace";
+            path: string;
+            value: unknown;
+        } | {
+            op: "remove";
+            path: string;
+            value?: unknown;
         };
         PaymentMethodReference: {
             /** Format: int32 */

--- a/test/patch-operation-types.ts
+++ b/test/patch-operation-types.ts
@@ -1,11 +1,11 @@
 import { expectTypeOf } from 'expect-type'
 import type { PatchOperation } from '../src/types'
 
-const addPatchOperation: PatchOperation = { op: 'add', path: 'summary', value: 'updated' }
-const replacePatchOperation: PatchOperation = { op: 'replace', path: 'summary', value: 'updated' }
-const removePatchOperation: PatchOperation = { op: 'remove', path: 'summary' }
+export const addPatchOperation: PatchOperation = { op: 'add', path: 'summary', value: 'updated' }
+export const replacePatchOperation: PatchOperation = { op: 'replace', path: 'summary', value: 'updated' }
+export const removePatchOperation: PatchOperation = { op: 'remove', path: 'summary' }
 // remove may still carry a value, existing consumers pass one
-const removePatchOperationWithValue: PatchOperation = { op: 'remove', path: 'summary', value: 'x' }
+export const removePatchOperationWithValue: PatchOperation = { op: 'remove', path: 'summary', value: 'x' }
 
 expectTypeOf<Extract<PatchOperation, { op: 'add' | 'replace' }>>().toEqualTypeOf<{
   op: 'add' | 'replace'
@@ -20,10 +20,10 @@ expectTypeOf<Extract<PatchOperation, { op: 'remove' }>>().toEqualTypeOf<{
 }>()
 
 // @ts-expect-error add operations should require a value.
-const addPatchOperationWithoutValue: PatchOperation = { op: 'add', path: 'summary' }
+export const addPatchOperationWithoutValue: PatchOperation = { op: 'add', path: 'summary' }
 
 // @ts-expect-error replace operations should require a value.
-const replacePatchOperationWithoutValue: PatchOperation = { op: 'replace', path: 'summary' }
+export const replacePatchOperationWithoutValue: PatchOperation = { op: 'replace', path: 'summary' }
 
 // @ts-expect-error patch operation op should be constrained to JSON patch operations.
-const invalidPatchOperation: PatchOperation = { op: 'copy', path: 'summary', value: 'updated' }
+export const invalidPatchOperation: PatchOperation = { op: 'copy', path: 'summary', value: 'updated' }

--- a/test/patch-operation-types.ts
+++ b/test/patch-operation-types.ts
@@ -4,10 +4,20 @@ import type { PatchOperation } from '../src/types'
 const addPatchOperation: PatchOperation = { op: 'add', path: 'summary', value: 'updated' }
 const replacePatchOperation: PatchOperation = { op: 'replace', path: 'summary', value: 'updated' }
 const removePatchOperation: PatchOperation = { op: 'remove', path: 'summary' }
+// remove may still carry a value, existing consumers pass one
+const removePatchOperationWithValue: PatchOperation = { op: 'remove', path: 'summary', value: 'x' }
 
-expectTypeOf(addPatchOperation.value).toEqualTypeOf<unknown>()
-expectTypeOf(replacePatchOperation.value).toEqualTypeOf<unknown>()
-expectTypeOf(removePatchOperation.value).toEqualTypeOf<unknown | undefined>()
+expectTypeOf<Extract<PatchOperation, { op: 'add' | 'replace' }>>().toEqualTypeOf<{
+  op: 'add' | 'replace'
+  path: string
+  value: unknown
+}>()
+
+expectTypeOf<Extract<PatchOperation, { op: 'remove' }>>().toEqualTypeOf<{
+  op: 'remove'
+  path: string
+  value?: unknown
+}>()
 
 // @ts-expect-error add operations should require a value.
 const addPatchOperationWithoutValue: PatchOperation = { op: 'add', path: 'summary' }

--- a/test/patch-operation-types.ts
+++ b/test/patch-operation-types.ts
@@ -1,0 +1,19 @@
+import { expectTypeOf } from 'expect-type'
+import type { PatchOperation } from '../src/types'
+
+const addPatchOperation: PatchOperation = { op: 'add', path: 'summary', value: 'updated' }
+const replacePatchOperation: PatchOperation = { op: 'replace', path: 'summary', value: 'updated' }
+const removePatchOperation: PatchOperation = { op: 'remove', path: 'summary' }
+
+expectTypeOf(addPatchOperation.value).toEqualTypeOf<unknown>()
+expectTypeOf(replacePatchOperation.value).toEqualTypeOf<unknown>()
+expectTypeOf(removePatchOperation.value).toEqualTypeOf<unknown | undefined>()
+
+// @ts-expect-error add operations should require a value.
+const addPatchOperationWithoutValue: PatchOperation = { op: 'add', path: 'summary' }
+
+// @ts-expect-error replace operations should require a value.
+const replacePatchOperationWithoutValue: PatchOperation = { op: 'replace', path: 'summary' }
+
+// @ts-expect-error patch operation op should be constrained to JSON patch operations.
+const invalidPatchOperation: PatchOperation = { op: 'copy', path: 'summary', value: 'updated' }

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -4,7 +4,7 @@
   "exclude": [],
   "compilerOptions": {
     "noEmit": true,
-    "rootDir": ".",
+    "rootDir": "..",
     "allowJs": true,
     "checkJs": false,
     "baseUrl": "."

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -60,6 +60,7 @@
     "intentionallyNotExported": [
       "schemas",
       "requestBodies",
+      "components",
       "AutomateConfig",
       "ManageConfig",
       "PaginationOptions"


### PR DESCRIPTION
# Changes
- Generates components.schemas.PatchOperation as a discriminated union from the Manage OpenAPI schema.
- Requires value for add and replace operations.
- Allows remove operations to omit value.
- Constrains op to valid patch operation values: add, replace, and remove.
- Updates the public ManageAPI PatchOperation export to reference the generated schema type, keeping a single source of truth.
- Adds type tests covering valid and invalid patch operation shapes.

# Why
The previous PatchOperation type allowed overly broad or inaccurate shapes, including unconstrained op values and optional/incorrectly typed fields. This change makes the public API safer and better aligned with expected patch semantics.