### PR TITLE
feat: support endpoint-specific request headers

### DIFF
--- a/generator/generator.js
+++ b/generator/generator.js
@@ -192,6 +192,14 @@ function generateAPIClass({ apiName, operations = [], generatorType }) {
         requestParams.push(`path: \`${url.replaceAll(/({.+?})/g, (_, p1) => `$${p1}`)}\``)
         requestParams.push(`method: '${method}'`)
 
+        if (
+          generatorType === 'Manage' &&
+          method === 'post' &&
+          url === '/system/members/{memberIdentifier}/tokens'
+        ) {
+          requestParams.push(`headers: { 'x-cw-usertype': 'member' }`)
+        }
+
         if (requestBody) {
           if (isMultipart) {
             usedToFormData = true

--- a/src/Automate.ts
+++ b/src/Automate.ts
@@ -177,6 +177,7 @@ export default class Automate {
     data,
     contentType,
     responseType,
+    headers: requestHeaders,
   }: RequestOptions): Promise<ErrorResponse | DataResponse> {
     const { username, password, serverUrl, twoFactorPasscode } = this.config
     if (!this.config.token || !this.instance) {
@@ -187,7 +188,9 @@ export default class Automate {
 
     try {
       const headers: Record<string, string> | undefined =
-        contentType === 'multipart' ? { 'Content-Type': 'multipart/form-data' } : undefined
+        contentType === 'multipart'
+          ? { ...requestHeaders, 'Content-Type': 'multipart/form-data' }
+          : requestHeaders
 
       const result = await this.instance({
         url: path,

--- a/src/BaseAPI.ts
+++ b/src/BaseAPI.ts
@@ -97,6 +97,7 @@ export const makeRequest =
     data,
     contentType,
     responseType,
+    headers,
   }: RequestOptions): Promise<unknown> => {
     const retryCodes = ['ECONNRESET', 'ETIMEDOUT', 'ESOCKETTIMEDOUT']
     const boundApi = api.bind(thisObj)
@@ -109,7 +110,7 @@ export const makeRequest =
     const { retry, retryOptions, logger } = config
 
     if (!retry) {
-      return boundApi({ path, method, params, data, contentType, responseType })
+      return boundApi({ path, method, params, data, contentType, responseType, headers })
         .then((result: any) => {
           logger(
             'info',
@@ -127,7 +128,7 @@ export const makeRequest =
         })
     } else {
       return promiseRetry(retryOptions, (retry, number) => {
-        return boundApi({ path, method, params, data, contentType, responseType }).catch(
+        return boundApi({ path, method, params, data, contentType, responseType, headers }).catch(
           (error) => {
             logger(
               'warn',

--- a/src/Manage.ts
+++ b/src/Manage.ts
@@ -157,6 +157,7 @@ export default class Manage {
     data,
     contentType,
     responseType,
+    headers: requestHeaders,
   }: RequestOptions): Promise<ErrorResponse | DataResponse> {
     try {
       // For multipart uploads let the runtime set Content-Type + boundary.
@@ -164,7 +165,9 @@ export default class Manage {
       // object with contentType: 'multipart' falls back to the caller's
       // FormData (consumers should use toFormData() from BaseAPI).
       const headers: Record<string, string> | undefined =
-        contentType === 'multipart' ? { 'Content-Type': 'multipart/form-data' } : undefined
+        contentType === 'multipart'
+          ? { ...requestHeaders, 'Content-Type': 'multipart/form-data' }
+          : requestHeaders
 
       const result = await this.instance({
         url: path,

--- a/src/Manage/SystemAPI.ts
+++ b/src/Manage/SystemAPI.ts
@@ -3124,6 +3124,7 @@ export class SystemAPI extends ManageBaseAPI {
     return this.request({
       path: `/system/members/${memberIdentifier}/tokens`,
       method: 'post',
+      headers: { 'x-cw-usertype': 'member' },
     })
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,8 @@ export type RequestOptions = {
   contentType?: ContentType
   /** Hint for how axios should decode the response; generator sets this for binary endpoints. */
   responseType?: ResponseType
+  /** Endpoint-specific headers to merge into the request. */
+  headers?: Record<string, string>
 }
 
 export type LoggingLevels = 'error' | 'warn' | 'info' | 'debug'

--- a/test/test-automate-request-options.mjs
+++ b/test/test-automate-request-options.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import dotenv from 'dotenv'
+import { beforeEach, describe, it } from 'mocha'
+import pkg from '../dist/index.js'
+const { AutomateAPI } = pkg
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+dotenv.config({ path: path.join(__dirname, '.env') })
+
+const {
+  AUTOMATE_API_CLIENT_ID = 'test-client-id',
+  AUTOMATE_API_URL = 'example.com',
+  AUTOMATE_API_USER = 'test-user',
+  AUTOMATE_API_PASSWORD = 'test-password',
+} = process.env
+
+describe('Automate request options', () => {
+  let cwa = null
+  let requestArgs = null
+
+  beforeEach(() => {
+    cwa = new AutomateAPI({
+      clientId: AUTOMATE_API_CLIENT_ID,
+      serverUrl: AUTOMATE_API_URL,
+      username: AUTOMATE_API_USER,
+      password: AUTOMATE_API_PASSWORD,
+      logger: () => {},
+    })
+    // token set so api() skips getToken
+    cwa.config.token = 'test-token'
+    requestArgs = null
+    cwa.instance = async (args) => {
+      requestArgs = args
+      return { data: [] }
+    }
+  })
+
+  describe('request headers', () => {
+    it('forwards endpoint headers to axios', async () => {
+      await cwa.request({ path: '/test', method: 'get', headers: { 'x-custom': 'value' } })
+
+      assert.deepStrictEqual(requestArgs.headers, { 'x-custom': 'value' })
+    })
+
+    it('merges headers under multipart content type', async () => {
+      await cwa.request({
+        path: '/test',
+        method: 'post',
+        data: 'body',
+        contentType: 'multipart',
+        headers: { 'x-custom': 'value' },
+      })
+
+      assert.deepStrictEqual(requestArgs.headers, {
+        'x-custom': 'value',
+        'Content-Type': 'multipart/form-data',
+      })
+    })
+  })
+})

--- a/test/test-manage-request-options.mjs
+++ b/test/test-manage-request-options.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import dotenv from 'dotenv'
+import { beforeEach, describe, it } from 'mocha'
+import pkg from '../dist/index.js'
+const { ManageAPI } = pkg
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+dotenv.config({ path: path.join(__dirname, '.env') })
+
+const {
+  MANAGE_API_COMPANY = 'test-company',
+  MANAGE_API_URL = 'example.com',
+  MANAGE_API_PUBLIC_KEY = 'test-public-key',
+  MANAGE_API_PRIVATE_KEY = 'test-private-key',
+  MANAGE_API_CLIENT_ID = 'test-client-id',
+} = process.env
+
+describe('Manage request options', () => {
+  let cwm = null
+  let requestArgs = null
+
+  beforeEach(() => {
+    cwm = new ManageAPI({
+      companyId: MANAGE_API_COMPANY,
+      companyUrl: MANAGE_API_URL,
+      publicKey: MANAGE_API_PUBLIC_KEY,
+      privateKey: MANAGE_API_PRIVATE_KEY,
+      clientId: MANAGE_API_CLIENT_ID,
+      apiVersion: '2021.2',
+      logger: () => {},
+    })
+    requestArgs = null
+    cwm.instance = async (args) => {
+      requestArgs = args
+      return { data: [] }
+    }
+  })
+
+  describe('request headers', () => {
+    it('adds member user type header when creating member tokens', async () => {
+      await cwm.SystemAPI.postSystemMembersByMemberIdentifierTokens('member-id')
+
+      assert.deepStrictEqual(requestArgs.headers, { 'x-cw-usertype': 'member' })
+    })
+  })
+
+  describe('binary downloads', () => {
+    it('requests document downloads as arraybuffers', async () => {
+      await cwm.SystemAPI.getSystemDocumentsByIdDownload(123)
+
+      assert.strictEqual(requestArgs.responseType, 'arraybuffer')
+    })
+
+    it('requests invoice PDFs as arraybuffers', async () => {
+      await cwm.FinanceAPI.getFinanceInvoicesByIdPdf(456)
+
+      assert.strictEqual(requestArgs.responseType, 'arraybuffer')
+    })
+  })
+})

--- a/test/test-manage.mjs
+++ b/test/test-manage.mjs
@@ -17,17 +17,17 @@ const {
   MANAGE_API_CLIENT_ID = 'test-client-id',
 } = process.env
 
-const cwm = new ManageAPI({
-  companyId: MANAGE_API_COMPANY,
-  companyUrl: MANAGE_API_URL,
-  publicKey: MANAGE_API_PUBLIC_KEY,
-  privateKey: MANAGE_API_PRIVATE_KEY,
-  clientId: MANAGE_API_CLIENT_ID,
-  apiVersion: '2021.2',
-  logger: () => {},
-})
-
 describe('Manage', () => {
+  const cwm = new ManageAPI({
+    companyId: MANAGE_API_COMPANY,
+    companyUrl: MANAGE_API_URL,
+    publicKey: MANAGE_API_PUBLIC_KEY,
+    privateKey: MANAGE_API_PRIVATE_KEY,
+    clientId: MANAGE_API_CLIENT_ID,
+    apiVersion: '2021.2',
+    logger: () => {},
+  })
+
   describe('instance', () => {
     it('should be an instance of ManageAPI', () => {
       assert(cwm instanceof ManageAPI)

--- a/test/test-request-options.mjs
+++ b/test/test-request-options.mjs
@@ -31,6 +31,7 @@ describe('request options', () => {
       data: 'body',
       contentType: 'multipart',
       responseType: 'arraybuffer',
+      headers: undefined,
     })
   })
 
@@ -64,6 +65,7 @@ describe('request options', () => {
       data: 'body',
       contentType: 'multipart',
       responseType: 'arraybuffer',
+      headers: undefined,
     })
   })
 })


### PR DESCRIPTION
# Changes

Adds support for endpoint-specific request headers in generated Manage API requests, including the required x-cw-usertype: member header for member token creation.
- Added headers to RequestOptions.
- Passed custom headers through makeRequest and Manage request execution.
- Updated multipart requests to merge custom headers with multipart Content-Type.
- Updated the generator to emit the member user type header for POST /system/members/{memberIdentifier}/tokens.
- Added tests for header forwarding and binary download response types.

# Why
ConnectWise Manage requires endpoint-specific headers for certain operations, such as creating member tokens. Without forwarding custom headers through the request pipeline, generated API methods could not satisfy those endpoint requirements. This change enables those headers while preserving existing request behavior.