### PR TITLE
feat: infer Manage field and orderBy types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## 2.0.0
 
+### Features
+
+#### Typed `fields` and `orderBy` on Manage common parameters
+
+`CommonParameters` is now generic over the endpoint's response model. `fields`
+accepts an array of model field paths (nested via `/`, e.g. `company/id`) and
+`orderBy` accepts `{ field, direction }` objects, both with autocomplete and
+compile-time validation. Arrays are serialized to the comma-separated strings the
+Manage API expects at request time.
+
+The plain-string forms (`fields: 'id,summary'`, `orderBy: 'id asc'`) remain
+accepted, both at the type level and at runtime, so existing code compiles
+unchanged. Bare `CommonParameters` (no type argument) stays valid and
+unconstrained.
+
 ### Breaking changes
 
 #### Axios instance count (correctness fix)

--- a/generator/generator.js
+++ b/generator/generator.js
@@ -3,6 +3,80 @@ const { getAutomateJson } = require('./automate-json')
 
 const automateSchema = getAutomateJson()
 
+const getRefName = (ref = '') => ref.split('/').pop()
+
+const getSchemaTypeFromRef = (ref = '') =>
+  ref.includes('requestBodies') ? 'requestBody' : 'schemas'
+
+const registerRefType = (types, ref) => {
+  const typeName = getRefName(ref)
+  types[typeName] = {
+    schemaType: getSchemaTypeFromRef(ref),
+  }
+  return typeName
+}
+
+const toResponseTypeInfo = (typeName, paramsType = typeName) => ({
+  returnType: typeMapSanitize(typeName),
+  paramsType: typeMapSanitize(paramsType),
+})
+
+const getResponseTypeInfo = ({ responses, types }) => {
+  if (responses[204]) {
+    return toResponseTypeInfo('NoContentResponse')
+  }
+
+  const { description, content } = responses[Object.keys(responses).pop()]
+
+  if (responses.default) {
+    return toResponseTypeInfo('any')
+  }
+
+  if (!content) {
+    const typeName = description.split(' ').pop()
+    return toResponseTypeInfo(typeName)
+  }
+
+  const { schema } = content[Object.keys(content).pop()]
+
+  if (schema.items) {
+    if (schema.items.$ref) {
+      const itemType = registerRefType(types, schema.items.$ref)
+      return toResponseTypeInfo(`Array<${itemType}>`, itemType)
+    }
+
+    if (schema.items.additionalProperties?.$ref) {
+      const itemType = registerRefType(types, schema.items.additionalProperties.$ref)
+      return toResponseTypeInfo(`Array<${itemType}>`, itemType)
+    }
+
+    if (schema.items.type) {
+      return toResponseTypeInfo(`Array<${schema.items.type}>`, schema.items.type)
+    }
+
+    if (schema.type) {
+      return toResponseTypeInfo(schema.type)
+    }
+  }
+
+  if (schema.$ref) {
+    const ref = schema.$ref
+
+    if (ref.includes('LabTech.Database.ResultSetWithCount')) {
+      const schemaName = getRefName(ref)
+      const resultSchema = automateSchema.components.schemas[schemaName]
+      const resultSetRef = resultSchema.properties.ResultSet.items.$ref
+      const itemType = registerRefType(types, resultSetRef)
+      return toResponseTypeInfo(`Array<${itemType}>`, itemType)
+    }
+
+    const typeName = registerRefType(types, ref)
+    return toResponseTypeInfo(typeName)
+  }
+
+  return toResponseTypeInfo(schema.type)
+}
+
 const typeMapSanitize = (input = '') => {
   switch (input) {
     case 'integer':
@@ -217,87 +291,25 @@ function generateAPIClass({ apiName, operations = [], generatorType }) {
           }
         }
 
-        if (queryParams.length > 0) {
-          functionParams.push('params: CommonParameters = {}')
-          requestParams.push(`params`)
-        }
-        let returnType
         let responseTypeHint = null
-        if (responses[204]) {
-          returnType = 'NoContentResponse'
-        } else {
-          const { description, content } = responses[Object.keys(responses).pop()]
+        const responseTypeInfo = getResponseTypeInfo({ responses, types })
+        let returnType = responseTypeInfo.returnType
 
-          // Detect non-JSON response content types and emit a responseType hint.
-          if (content) {
-            const contentTypes = Object.keys(content)
-            if (
-              contentTypes.includes('application/octet-stream') ||
-              contentTypes.includes('application/pdf')
-            ) {
-              responseTypeHint = 'arraybuffer'
-            } else if (contentTypes.includes('text/html')) {
-              responseTypeHint = 'text'
-            }
-          }
+        const response = responses[Object.keys(responses).pop()]
+        const content = response?.content
 
-          if (responses['default']) {
-            returnType = 'any'
-            if (responses['default'].description) {
-              returnType = `${returnType}`
-            }
-          } else if (content) {
-            const { schema } = content[Object.keys(content).pop()]
-
-            if (schema.items) {
-              if (schema.items.$ref) {
-                const ref = schema.items.$ref
-                const tempName = ref.split('/').pop()
-                returnType = `Array<${tempName}>`
-                types[tempName] = {
-                  schemaType: ref.includes('requestBodies') ? 'requestBody' : 'schemas',
-                }
-              } else if (schema.items.additionalProperties?.$ref) {
-                const ref = schema.items.additionalProperties.$ref
-                const tempName = ref.split('/').pop()
-                returnType = `Array<${tempName}>`
-                types[tempName] = {
-                  schemaType: ref.includes('requestBodies') ? 'requestBody' : 'schemas',
-                }
-              } else if (schema.type) {
-                if (schema.items.type) {
-                  returnType = `Array<${schema.items.type}>`
-                } else {
-                  returnType = schema.type
-                }
-              }
-            } else if (schema.$ref) {
-              const ref = schema.$ref
-              // fix for incorrect types from ResultSetWithCount
-              if (ref.includes('LabTech.Database.ResultSetWithCount')) {
-                const schemaName = ref.split('/').pop()
-                const resultSchema = automateSchema.components.schemas[schemaName]
-                const ResultSetRef = resultSchema.properties.ResultSet.items.$ref
-                const tempName = ResultSetRef.split('/').pop()
-                returnType = `Array<${tempName}>`
-                types[tempName] = {
-                  schemaType: ref.includes('requestBodies') ? 'requestBody' : 'schemas',
-                }
-              } else {
-                returnType = schema.$ref.split('/').pop()
-                types[returnType] = {
-                  schemaType: ref.includes('requestBodies') ? 'requestBody' : 'schemas',
-                }
-              }
-            } else {
-              returnType = schema.type
-            }
-          } else {
-            returnType = description.split(' ').pop()
+        // Detect non-JSON response content types and emit a responseType hint.
+        if (content) {
+          const contentTypes = Object.keys(content)
+          if (
+            contentTypes.includes('application/octet-stream') ||
+            contentTypes.includes('application/pdf')
+          ) {
+            responseTypeHint = 'arraybuffer'
+          } else if (contentTypes.includes('text/html')) {
+            responseTypeHint = 'text'
           }
         }
-
-        returnType = typeMapSanitize(returnType)
 
         if (!returnType) {
           returnType = 'any'
@@ -305,6 +317,15 @@ function generateAPIClass({ apiName, operations = [], generatorType }) {
 
         if (responseTypeHint) {
           requestParams.push(`responseType: '${responseTypeHint}'`)
+        }
+
+        if (queryParams.length > 0) {
+          const commonParametersType =
+            generatorType === 'Manage'
+              ? `CommonParameters<${responseTypeInfo.paramsType}>`
+              : 'CommonParameters'
+          functionParams.push(`params: ${commonParametersType} = {}`)
+          requestParams.push(`params`)
         }
 
         return `

--- a/generator/manage-generator.js
+++ b/generator/manage-generator.js
@@ -211,12 +211,12 @@ type OrderByValue<T> = ReadonlyArray<{
  * @public
  * Manage common parameters
  */
-export type CommonParameters<T> = {
+export type CommonParameters<T = any> = {
   conditions?: string
   childConditions?: string
   customFieldConditions?: string
-  orderBy?: OrderByValue<T>
-  fields?: FieldSelection<T>
+  orderBy?: OrderByValue<T> | string
+  fields?: FieldSelection<T> | string
   page?: number
   pageSize?: number
   pageId?: number

--- a/generator/manage-generator.js
+++ b/generator/manage-generator.js
@@ -174,16 +174,49 @@ export interface CWMOptions {
   debug?: boolean
 }
 
+type FieldPathPrimitive = bigint | boolean | null | number | string | symbol | undefined
+
+type FieldPathTerminal = Date | FieldPathPrimitive | RegExp
+
+type FieldPathValue<T> = T extends ReadonlyArray<infer U> ? U : T
+
+type FieldPathDepth = [never, 0, 1, 2, 3, 4, 5]
+
+type FieldPath<T, Depth extends number = 5> = [Depth] extends [never]
+  ? never
+  : T extends FieldPathTerminal
+    ? never
+    : T extends object
+      ? {
+          [K in keyof T & string]: NonNullable<T[K]> extends FieldPathTerminal
+            ? K
+            : NonNullable<FieldPathValue<T[K]>> extends object
+              ? K | \`\${K}/\${FieldPath<NonNullable<FieldPathValue<T[K]>>, FieldPathDepth[Depth]>}\`
+              : K
+        }[keyof T & string]
+      : never
+
+type FieldSelection<T> = ReadonlyArray<FieldPath<NonNullable<T>>>
+
+type OrderByField<T> = FieldPath<NonNullable<T>>
+
+type SortOrder = 'asc' | 'desc'
+
+type OrderByValue<T> = ReadonlyArray<{
+  field: OrderByField<T>
+  direction: SortOrder
+}>
+
 /**
  * @public
  * Manage common parameters
  */
-export type CommonParameters = {
+export type CommonParameters<T> = {
   conditions?: string
   childConditions?: string
   customFieldConditions?: string
-  orderBy?: string
-  fields?: string
+  orderBy?: OrderByValue<T>
+  fields?: FieldSelection<T>
   page?: number
   pageSize?: number
   pageId?: number

--- a/src/Manage.ts
+++ b/src/Manage.ts
@@ -169,12 +169,16 @@ export default class Manage {
           ? { ...requestHeaders, 'Content-Type': 'multipart/form-data' }
           : requestHeaders
 
+      // empty arrays return undefined so axios omits the param entirely
       const normalizeFieldValue = (value: unknown) =>
-        Array.isArray(value) ? value.join(',') : value
+        Array.isArray(value) ? (value.length ? value.join(',') : undefined) : value
 
       const normalizeOrderByValue = (value: unknown) => {
         if (!Array.isArray(value)) {
           return value
+        }
+        if (!value.length) {
+          return undefined
         }
 
         return value

--- a/src/Manage.ts
+++ b/src/Manage.ts
@@ -169,10 +169,39 @@ export default class Manage {
           ? { ...requestHeaders, 'Content-Type': 'multipart/form-data' }
           : requestHeaders
 
+      const normalizeFieldValue = (value: unknown) =>
+        Array.isArray(value) ? value.join(',') : value
+
+      const normalizeOrderByValue = (value: unknown) => {
+        if (!Array.isArray(value)) {
+          return value
+        }
+
+        return value
+          .map((item) => {
+            if (!item || typeof item !== 'object' || !('field' in item) || !('direction' in item)) {
+              return item
+            }
+
+            const { field, direction } = item as { field: string; direction: 'asc' | 'desc' }
+            return `${field} ${direction}`
+          })
+          .join(',')
+      }
+
+      const normalizedParams =
+        params && typeof params === 'object' && ('fields' in params || 'orderBy' in params)
+          ? {
+              ...params,
+              fields: normalizeFieldValue(params.fields),
+              orderBy: normalizeOrderByValue(params.orderBy),
+            }
+          : params
+
       const result = await this.instance({
         url: path,
         method,
-        params,
+        params: normalizedParams,
         data,
         headers,
         responseType: responseType ?? 'json',

--- a/src/Manage/CompanyAPI.ts
+++ b/src/Manage/CompanyAPI.ts
@@ -202,7 +202,9 @@ export type ValidatePortalResponse = schemas['ValidatePortalResponse']
  * @public
  */
 export class CompanyAPI extends ManageBaseAPI {
-  getCompanyAddressFormats(params: CommonParameters = {}): Promise<Array<AddressFormat>> {
+  getCompanyAddressFormats(
+    params: CommonParameters<AddressFormat> = {},
+  ): Promise<Array<AddressFormat>> {
     return this.request({
       path: `/company/addressFormats`,
       method: 'get',
@@ -218,7 +220,10 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyAddressFormatsById(id: number, params: CommonParameters = {}): Promise<AddressFormat> {
+  getCompanyAddressFormatsById(
+    id: number,
+    params: CommonParameters<AddressFormat> = {},
+  ): Promise<AddressFormat> {
     return this.request({
       path: `/company/addressFormats/${id}`,
       method: 'get',
@@ -254,7 +259,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyAddressFormatsByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AddressFormatInfo> = {},
   ): Promise<AddressFormatInfo> {
     return this.request({
       path: `/company/addressFormats/${id}/info`,
@@ -263,7 +268,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyAddressFormatsCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyAddressFormatsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/addressFormats/count`,
       method: 'get',
@@ -271,7 +276,9 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyAddressFormatsInfo(params: CommonParameters = {}): Promise<Array<AddressFormatInfo>> {
+  getCompanyAddressFormatsInfo(
+    params: CommonParameters<AddressFormatInfo> = {},
+  ): Promise<Array<AddressFormatInfo>> {
     return this.request({
       path: `/company/addressFormats/info`,
       method: 'get',
@@ -279,7 +286,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyAddressFormatsInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyAddressFormatsInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/addressFormats/info/count`,
       method: 'get',
@@ -287,7 +294,9 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyCommunicationTypes(params: CommonParameters = {}): Promise<Array<CommunicationType>> {
+  getCompanyCommunicationTypes(
+    params: CommonParameters<CommunicationType> = {},
+  ): Promise<Array<CommunicationType>> {
     return this.request({
       path: `/company/communicationTypes`,
       method: 'get',
@@ -305,7 +314,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCommunicationTypesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CommunicationType> = {},
   ): Promise<CommunicationType> {
     return this.request({
       path: `/company/communicationTypes/${id}`,
@@ -345,7 +354,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCommunicationTypesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CommunicationTypeInfo> = {},
   ): Promise<CommunicationTypeInfo> {
     return this.request({
       path: `/company/communicationTypes/${id}/info`,
@@ -356,7 +365,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCommunicationTypesByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/communicationTypes/${id}/usages`,
@@ -367,7 +376,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCommunicationTypesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/communicationTypes/${id}/usages/list`,
@@ -376,7 +385,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyCommunicationTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyCommunicationTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/communicationTypes/count`,
       method: 'get',
@@ -385,7 +394,7 @@ export class CompanyAPI extends ManageBaseAPI {
   }
 
   getCompanyCommunicationTypesInfo(
-    params: CommonParameters = {},
+    params: CommonParameters<CommunicationTypeInfo> = {},
   ): Promise<Array<CommunicationTypeInfo>> {
     return this.request({
       path: `/company/communicationTypes/info`,
@@ -394,7 +403,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyCommunicationTypesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyCommunicationTypesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/communicationTypes/info/count`,
       method: 'get',
@@ -402,7 +411,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyCompanies(params: CommonParameters = {}): Promise<Array<Company>> {
+  getCompanyCompanies(params: CommonParameters<Company> = {}): Promise<Array<Company>> {
     return this.request({
       path: `/company/companies`,
       method: 'get',
@@ -418,7 +427,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyCompaniesById(id: number, params: CommonParameters = {}): Promise<Company> {
+  getCompanyCompaniesById(id: number, params: CommonParameters<Company> = {}): Promise<Company> {
     return this.request({
       path: `/company/companies/${id}`,
       method: 'get',
@@ -457,7 +466,10 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyCompaniesByIdUsages(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getCompanyCompaniesByIdUsages(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/companies/${id}/usages`,
       method: 'get',
@@ -467,7 +479,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/companies/${id}/usages/list`,
@@ -478,7 +490,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesByParentIdCustomStatusNotes(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyCustomNote> = {},
   ): Promise<Array<CompanyCustomNote>> {
     return this.request({
       path: `/company/companies/${parentId}/customStatusNotes`,
@@ -501,7 +513,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyCompaniesByParentIdCustomStatusNotesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyCustomNote> = {},
   ): Promise<CompanyCustomNote> {
     return this.request({
       path: `/company/companies/${parentId}/customStatusNotes/${id}`,
@@ -546,7 +558,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesByParentIdCustomStatusNotesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/companies/${parentId}/customStatusNotes/count`,
@@ -557,7 +569,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesByParentIdGroups(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyGroup> = {},
   ): Promise<Array<CompanyGroup>> {
     return this.request({
       path: `/company/companies/${parentId}/groups`,
@@ -580,7 +592,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyCompaniesByParentIdGroupsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyGroup> = {},
   ): Promise<CompanyGroup> {
     return this.request({
       path: `/company/companies/${parentId}/groups/${id}`,
@@ -625,7 +637,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesByParentIdGroupsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/companies/${parentId}/groups/count`,
@@ -636,7 +648,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesByParentIdManagementReportNotifications(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ManagementReportNotification> = {},
   ): Promise<Array<ManagementReportNotification>> {
     return this.request({
       path: `/company/companies/${parentId}/managementReportNotifications`,
@@ -659,7 +671,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyCompaniesByParentIdManagementReportNotificationsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ManagementReportNotification> = {},
   ): Promise<ManagementReportNotification> {
     return this.request({
       path: `/company/companies/${parentId}/managementReportNotifications/${id}`,
@@ -704,7 +716,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesByParentIdManagementReportNotificationsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/companies/${parentId}/managementReportNotifications/count`,
@@ -715,7 +727,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesByParentIdManagementReportSetup(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ManagementReportSetup> = {},
   ): Promise<Array<ManagementReportSetup>> {
     return this.request({
       path: `/company/companies/${parentId}/managementReportSetup`,
@@ -761,7 +773,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesByParentIdManagementSummaryReports(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyManagementSummary> = {},
   ): Promise<Array<CompanyManagementSummary>> {
     return this.request({
       path: `/company/companies/${parentId}/managementSummaryReports`,
@@ -784,7 +796,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyCompaniesByParentIdManagementSummaryReportsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyManagementSummary> = {},
   ): Promise<CompanyManagementSummary> {
     return this.request({
       path: `/company/companies/${parentId}/managementSummaryReports/${id}`,
@@ -829,7 +841,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesByParentIdManagementSummaryReportsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/companies/${parentId}/managementSummaryReports/count`,
@@ -840,7 +852,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesByParentIdNotes(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyNote> = {},
   ): Promise<Array<CompanyNote>> {
     return this.request({
       path: `/company/companies/${parentId}/notes`,
@@ -863,7 +875,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyCompaniesByParentIdNotesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyNote> = {},
   ): Promise<CompanyNote> {
     return this.request({
       path: `/company/companies/${parentId}/notes/${id}`,
@@ -908,7 +920,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesByParentIdNotesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/companies/${parentId}/notes/count`,
@@ -919,7 +931,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesByParentIdServiceTemplates(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyServiceTemplate> = {},
   ): Promise<Array<CompanyServiceTemplate>> {
     return this.request({
       path: `/company/companies/${parentId}/serviceTemplates`,
@@ -942,7 +954,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyCompaniesByParentIdServiceTemplatesById(
     parentId: number,
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ServiceTemplate> = {},
   ): Promise<ServiceTemplate> {
     return this.request({
       path: `/company/companies/${parentId}/serviceTemplates/${id}`,
@@ -1029,7 +1041,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesByParentIdServiceTemplatesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/companies/${parentId}/serviceTemplates/count`,
@@ -1040,7 +1052,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesByParentIdSites(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanySite> = {},
   ): Promise<Array<CompanySite>> {
     return this.request({
       path: `/company/companies/${parentId}/sites`,
@@ -1060,7 +1072,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyCompaniesByParentIdSitesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanySite> = {},
   ): Promise<CompanySite> {
     return this.request({
       path: `/company/companies/${parentId}/sites/${id}`,
@@ -1106,7 +1118,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyCompaniesByParentIdSitesByIdInfo(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanySiteInfo> = {},
   ): Promise<CompanySiteInfo> {
     return this.request({
       path: `/company/companies/${parentId}/sites/${id}/info`,
@@ -1118,7 +1130,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyCompaniesByParentIdSitesByIdUsages(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/companies/${parentId}/sites/${id}/usages`,
@@ -1130,7 +1142,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyCompaniesByParentIdSitesByIdUsagesList(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/companies/${parentId}/sites/${id}/usages/list`,
@@ -1141,7 +1153,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesByParentIdSitesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/companies/${parentId}/sites/count`,
@@ -1152,7 +1164,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesByParentIdSitesInfo(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanySiteInfo> = {},
   ): Promise<Array<CompanySiteInfo>> {
     return this.request({
       path: `/company/companies/${parentId}/sites/info`,
@@ -1163,7 +1175,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesByParentIdSitesInfoCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/companies/${parentId}/sites/info/count`,
@@ -1174,7 +1186,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesByParentIdSurveysCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/companies/${parentId}/surveys/count`,
@@ -1185,7 +1197,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesByParentIdTeams(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyTeam> = {},
   ): Promise<Array<CompanyTeam>> {
     return this.request({
       path: `/company/companies/${parentId}/teams`,
@@ -1208,7 +1220,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyCompaniesByParentIdTeamsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyTeam> = {},
   ): Promise<CompanyTeam> {
     return this.request({
       path: `/company/companies/${parentId}/teams/${id}`,
@@ -1253,7 +1265,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesByParentIdTeamsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/companies/${parentId}/teams/count`,
@@ -1264,7 +1276,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesByParentIdTracks(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ContactTrack> = {},
   ): Promise<Array<ContactTrack>> {
     return this.request({
       path: `/company/companies/${parentId}/tracks`,
@@ -1287,7 +1299,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyCompaniesByParentIdTracksById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ContactTrack> = {},
   ): Promise<ContactTrack> {
     return this.request({
       path: `/company/companies/${parentId}/tracks/${id}`,
@@ -1308,7 +1320,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesByParentIdTracksCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/companies/${parentId}/tracks/count`,
@@ -1319,7 +1331,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesByParentIdTypeAssociations(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyCompanyTypeAssociationCompanyTypeAssociation> = {},
   ): Promise<Array<CompanyCompanyTypeAssociationCompanyTypeAssociation>> {
     return this.request({
       path: `/company/companies/${parentId}/typeAssociations`,
@@ -1342,7 +1354,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyCompaniesByParentIdTypeAssociationsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyCompanyTypeAssociationCompanyTypeAssociation> = {},
   ): Promise<CompanyCompanyTypeAssociationCompanyTypeAssociation> {
     return this.request({
       path: `/company/companies/${parentId}/typeAssociations/${id}`,
@@ -1387,7 +1399,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesByParentIdTypeAssociationsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/companies/${parentId}/typeAssociations/count`,
@@ -1396,7 +1408,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyCompaniesCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyCompaniesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/companies/count`,
       method: 'get',
@@ -1404,7 +1416,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyCompaniesDefault(params: CommonParameters = {}): Promise<Company> {
+  getCompanyCompaniesDefault(params: CommonParameters<Company> = {}): Promise<Company> {
     return this.request({
       path: `/company/companies/default`,
       method: 'get',
@@ -1412,7 +1424,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyCompaniesInfo(params: CommonParameters = {}): Promise<Array<CompanyInfo>> {
+  getCompanyCompaniesInfo(params: CommonParameters<CompanyInfo> = {}): Promise<Array<CompanyInfo>> {
     return this.request({
       path: `/company/companies/info`,
       method: 'get',
@@ -1420,7 +1432,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyCompaniesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyCompaniesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/companies/info/count`,
       method: 'get',
@@ -1428,7 +1440,9 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyCompaniesInfoTypes(params: CommonParameters = {}): Promise<Array<CompanyTypeInfo>> {
+  getCompanyCompaniesInfoTypes(
+    params: CommonParameters<CompanyTypeInfo> = {},
+  ): Promise<Array<CompanyTypeInfo>> {
     return this.request({
       path: `/company/companies/info/types`,
       method: 'get',
@@ -1438,7 +1452,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesInfoTypesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyTypeInfo> = {},
   ): Promise<CompanyTypeInfo> {
     return this.request({
       path: `/company/companies/info/types/${id}`,
@@ -1447,7 +1461,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyCompaniesInfoTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyCompaniesInfoTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/companies/info/types/count`,
       method: 'get',
@@ -1455,7 +1469,9 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyCompaniesStatuses(params: CommonParameters = {}): Promise<Array<CompanyStatus>> {
+  getCompanyCompaniesStatuses(
+    params: CommonParameters<CompanyStatus> = {},
+  ): Promise<Array<CompanyStatus>> {
     return this.request({
       path: `/company/companies/statuses`,
       method: 'get',
@@ -1473,7 +1489,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesStatusesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyStatus> = {},
   ): Promise<CompanyStatus> {
     return this.request({
       path: `/company/companies/statuses/${id}`,
@@ -1513,7 +1529,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesStatusesByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/companies/statuses/${id}/usages`,
@@ -1524,7 +1540,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesStatusesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/companies/statuses/${id}/usages/list`,
@@ -1533,7 +1549,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyCompaniesStatusesCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyCompaniesStatusesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/companies/statuses/count`,
       method: 'get',
@@ -1541,7 +1557,9 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyCompaniesTypes(params: CommonParameters = {}): Promise<Array<CompanyType>> {
+  getCompanyCompaniesTypes(
+    params: CommonParameters<CompanyType> = {},
+  ): Promise<Array<CompanyType>> {
     return this.request({
       path: `/company/companies/types`,
       method: 'get',
@@ -1557,7 +1575,10 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyCompaniesTypesById(id: number, params: CommonParameters = {}): Promise<CompanyType> {
+  getCompanyCompaniesTypesById(
+    id: number,
+    params: CommonParameters<CompanyType> = {},
+  ): Promise<CompanyType> {
     return this.request({
       path: `/company/companies/types/${id}`,
       method: 'get',
@@ -1593,7 +1614,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesTypesByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/companies/types/${id}/usages`,
@@ -1604,7 +1625,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompaniesTypesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/companies/types/${id}/usages/list`,
@@ -1613,7 +1634,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyCompaniesTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyCompaniesTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/companies/types/count`,
       method: 'get',
@@ -1621,7 +1642,9 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyCompanyPickerItems(params: CommonParameters = {}): Promise<Array<CompanyPickerItem>> {
+  getCompanyCompanyPickerItems(
+    params: CommonParameters<CompanyPickerItem> = {},
+  ): Promise<Array<CompanyPickerItem>> {
     return this.request({
       path: `/company/companyPickerItems`,
       method: 'get',
@@ -1639,7 +1662,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompanyPickerItemsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyPickerItem> = {},
   ): Promise<CompanyPickerItem> {
     return this.request({
       path: `/company/companyPickerItems/${id}`,
@@ -1662,7 +1685,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyCompanyPickerItemsCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyCompanyPickerItemsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/companyPickerItems/count`,
       method: 'get',
@@ -1671,7 +1694,7 @@ export class CompanyAPI extends ManageBaseAPI {
   }
 
   getCompanyCompanyTypeAssociations(
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyCompanyTypeAssociation> = {},
   ): Promise<Array<CompanyCompanyTypeAssociation>> {
     return this.request({
       path: `/company/companyTypeAssociations`,
@@ -1692,7 +1715,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyCompanyTypeAssociationsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyCompanyTypeAssociation> = {},
   ): Promise<CompanyCompanyTypeAssociation> {
     return this.request({
       path: `/company/companyTypeAssociations/${id}`,
@@ -1730,7 +1753,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyCompanyTypeAssociationsCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyCompanyTypeAssociationsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/companyTypeAssociations/count`,
       method: 'get',
@@ -1738,7 +1761,9 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyConfigurations(params: CommonParameters = {}): Promise<Array<CompanyConfiguration>> {
+  getCompanyConfigurations(
+    params: CommonParameters<CompanyConfiguration> = {},
+  ): Promise<Array<CompanyConfiguration>> {
     return this.request({
       path: `/company/configurations`,
       method: 'get',
@@ -1748,7 +1773,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   postCompanyConfigurations(
     configuration: CompanyConfiguration,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyConfiguration> = {},
   ): Promise<CompanyConfiguration> {
     return this.request({
       path: `/company/configurations`,
@@ -1760,7 +1785,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyConfigurationsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyConfiguration> = {},
   ): Promise<CompanyConfiguration> {
     return this.request({
       path: `/company/configurations/${id}`,
@@ -1779,7 +1804,7 @@ export class CompanyAPI extends ManageBaseAPI {
   putCompanyConfigurationsById(
     id: number,
     configuration: CompanyConfiguration,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyConfiguration> = {},
   ): Promise<CompanyConfiguration> {
     return this.request({
       path: `/company/configurations/${id}`,
@@ -1792,7 +1817,7 @@ export class CompanyAPI extends ManageBaseAPI {
   patchCompanyConfigurationsById(
     id: number,
     patchOperations: Array<PatchOperation>,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyConfiguration> = {},
   ): Promise<CompanyConfiguration> {
     return this.request({
       path: `/company/configurations/${id}`,
@@ -1815,7 +1840,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyConfigurationsByIdQuickAccessCount(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ConfigurationTabsCount> = {},
   ): Promise<ConfigurationTabsCount> {
     return this.request({
       path: `/company/configurations/${id}/quickAccess/count`,
@@ -1826,7 +1851,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   postCompanyConfigurationsBulk(
     companyConfigurations: Array<CompanyConfiguration>,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyConfiguration> = {},
   ): Promise<CompanyConfiguration> {
     return this.request({
       path: `/company/configurations/bulk`,
@@ -1845,7 +1870,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   putCompanyConfigurationsBulk(
     companyConfigurations: Array<CompanyConfiguration>,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyConfiguration> = {},
   ): Promise<CompanyConfiguration> {
     return this.request({
       path: `/company/configurations/bulk`,
@@ -1855,7 +1880,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyConfigurationsCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyConfigurationsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/configurations/count`,
       method: 'get',
@@ -1864,7 +1889,7 @@ export class CompanyAPI extends ManageBaseAPI {
   }
 
   getCompanyConfigurationsStatuses(
-    params: CommonParameters = {},
+    params: CommonParameters<ConfigurationStatus> = {},
   ): Promise<Array<ConfigurationStatus>> {
     return this.request({
       path: `/company/configurations/statuses`,
@@ -1885,7 +1910,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyConfigurationsStatusesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ConfigurationStatus> = {},
   ): Promise<ConfigurationStatus> {
     return this.request({
       path: `/company/configurations/statuses/${id}`,
@@ -1925,7 +1950,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyConfigurationsStatusesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ConfigurationStatusInfo> = {},
   ): Promise<ConfigurationStatusInfo> {
     return this.request({
       path: `/company/configurations/statuses/${id}/info`,
@@ -1936,7 +1961,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyConfigurationsStatusesByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/configurations/statuses/${id}/usages`,
@@ -1947,7 +1972,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyConfigurationsStatusesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/configurations/statuses/${id}/usages/list`,
@@ -1956,7 +1981,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyConfigurationsStatusesCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyConfigurationsStatusesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/configurations/statuses/count`,
       method: 'get',
@@ -1965,7 +1990,7 @@ export class CompanyAPI extends ManageBaseAPI {
   }
 
   getCompanyConfigurationsStatusesInfo(
-    params: CommonParameters = {},
+    params: CommonParameters<ConfigurationStatusInfo> = {},
   ): Promise<Array<ConfigurationStatusInfo>> {
     return this.request({
       path: `/company/configurations/statuses/info`,
@@ -1974,7 +1999,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyConfigurationsStatusesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyConfigurationsStatusesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/configurations/statuses/info/count`,
       method: 'get',
@@ -1982,7 +2007,9 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyConfigurationsTypes(params: CommonParameters = {}): Promise<Array<ConfigurationType>> {
+  getCompanyConfigurationsTypes(
+    params: CommonParameters<ConfigurationType> = {},
+  ): Promise<Array<ConfigurationType>> {
     return this.request({
       path: `/company/configurations/types`,
       method: 'get',
@@ -2001,7 +2028,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyConfigurationsTypesByGrandparentIdQuestionsByParentIdValues(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ConfigurationTypeQuestionValue> = {},
   ): Promise<Array<ConfigurationTypeQuestionValue>> {
     return this.request({
       path: `/company/configurations/types/${grandparentId}/questions/${parentId}/values`,
@@ -2026,7 +2053,7 @@ export class CompanyAPI extends ManageBaseAPI {
     id: number,
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ConfigurationTypeQuestionValue> = {},
   ): Promise<ConfigurationTypeQuestionValue> {
     return this.request({
       path: `/company/configurations/types/${grandparentId}/questions/${parentId}/values/${id}`,
@@ -2076,7 +2103,7 @@ export class CompanyAPI extends ManageBaseAPI {
     id: number,
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/configurations/types/${grandparentId}/questions/${parentId}/values/${id}/usages`,
@@ -2089,7 +2116,7 @@ export class CompanyAPI extends ManageBaseAPI {
     id: number,
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/configurations/types/${grandparentId}/questions/${parentId}/values/${id}/usages/list`,
@@ -2101,7 +2128,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyConfigurationsTypesByGrandparentIdQuestionsByParentIdValuesCount(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/configurations/types/${grandparentId}/questions/${parentId}/values/count`,
@@ -2112,7 +2139,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyConfigurationsTypesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ConfigurationType> = {},
   ): Promise<ConfigurationType> {
     return this.request({
       path: `/company/configurations/types/${id}`,
@@ -2152,7 +2179,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyConfigurationsTypesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ConfigurationTypeInfo> = {},
   ): Promise<ConfigurationTypeInfo> {
     return this.request({
       path: `/company/configurations/types/${id}/info`,
@@ -2163,7 +2190,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyConfigurationsTypesByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/configurations/types/${id}/usages`,
@@ -2174,7 +2201,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyConfigurationsTypesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/configurations/types/${id}/usages/list`,
@@ -2185,7 +2212,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyConfigurationsTypesByParentIdQuestions(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ConfigurationTypeQuestion> = {},
   ): Promise<Array<ConfigurationTypeQuestion>> {
     return this.request({
       path: `/company/configurations/types/${parentId}/questions`,
@@ -2208,7 +2235,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyConfigurationsTypesByParentIdQuestionsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ConfigurationTypeQuestion> = {},
   ): Promise<ConfigurationTypeQuestion> {
     return this.request({
       path: `/company/configurations/types/${parentId}/questions/${id}`,
@@ -2253,7 +2280,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyConfigurationsTypesByParentIdQuestionsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/configurations/types/${parentId}/questions/count`,
@@ -2270,7 +2297,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyConfigurationsTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyConfigurationsTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/configurations/types/count`,
       method: 'get',
@@ -2280,7 +2307,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyContactTypesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/contact/types/${id}/usages/list`,
@@ -2289,7 +2316,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyContacts(params: CommonParameters = {}): Promise<Array<Contact>> {
+  getCompanyContacts(params: CommonParameters<Contact> = {}): Promise<Array<Contact>> {
     return this.request({
       path: `/company/contacts`,
       method: 'get',
@@ -2305,7 +2332,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyContactsById(id: number, params: CommonParameters = {}): Promise<Contact> {
+  getCompanyContactsById(id: number, params: CommonParameters<Contact> = {}): Promise<Contact> {
     return this.request({
       path: `/company/contacts/${id}`,
       method: 'get',
@@ -2313,7 +2340,10 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  deleteCompanyContactsById(id: number, params: CommonParameters = {}): Promise<NoContentResponse> {
+  deleteCompanyContactsById(
+    id: number,
+    params: CommonParameters<NoContentResponse> = {},
+  ): Promise<NoContentResponse> {
     return this.request({
       path: `/company/contacts/${id}`,
       method: 'delete',
@@ -2339,7 +2369,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyContactsByIdImage(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<OctetStreamResponse> = {},
   ): Promise<OctetStreamResponse> {
     return this.request({
       path: `/company/contacts/${id}/image`,
@@ -2348,7 +2378,10 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyContactsByIdInfo(id: number, params: CommonParameters = {}): Promise<ContactInfo> {
+  getCompanyContactsByIdInfo(
+    id: number,
+    params: CommonParameters<ContactInfo> = {},
+  ): Promise<ContactInfo> {
     return this.request({
       path: `/company/contacts/${id}/info`,
       method: 'get',
@@ -2358,7 +2391,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyContactsByIdPortalSecurity(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PortalSecurity> = {},
   ): Promise<Array<PortalSecurity>> {
     return this.request({
       path: `/company/contacts/${id}/portalSecurity`,
@@ -2367,7 +2400,10 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyContactsByIdUsages(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getCompanyContactsByIdUsages(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/contacts/${id}/usages`,
       method: 'get',
@@ -2377,7 +2413,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyContactsByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/contacts/${id}/usages/list`,
@@ -2388,7 +2424,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyContactsByParentIdCommunications(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ContactCommunication> = {},
   ): Promise<Array<ContactCommunication>> {
     return this.request({
       path: `/company/contacts/${parentId}/communications`,
@@ -2411,7 +2447,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyContactsByParentIdCommunicationsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ContactCommunication> = {},
   ): Promise<ContactCommunication> {
     return this.request({
       path: `/company/contacts/${parentId}/communications/${id}`,
@@ -2456,7 +2492,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyContactsByParentIdCommunicationsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/contacts/${parentId}/communications/count`,
@@ -2467,7 +2503,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyContactsByParentIdGroups(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ContactGroup> = {},
   ): Promise<Array<ContactGroup>> {
     return this.request({
       path: `/company/contacts/${parentId}/groups`,
@@ -2490,7 +2526,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyContactsByParentIdGroupsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ContactGroup> = {},
   ): Promise<ContactGroup> {
     return this.request({
       path: `/company/contacts/${parentId}/groups/${id}`,
@@ -2535,7 +2571,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyContactsByParentIdGroupsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/contacts/${parentId}/groups/count`,
@@ -2546,7 +2582,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyContactsByParentIdNotes(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ContactNote> = {},
   ): Promise<Array<ContactNote>> {
     return this.request({
       path: `/company/contacts/${parentId}/notes`,
@@ -2569,7 +2605,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyContactsByParentIdNotesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ContactNote> = {},
   ): Promise<ContactNote> {
     return this.request({
       path: `/company/contacts/${parentId}/notes/${id}`,
@@ -2614,7 +2650,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyContactsByParentIdNotesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/contacts/${parentId}/notes/count`,
@@ -2625,7 +2661,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyContactsByParentIdTracks(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ContactTrack> = {},
   ): Promise<Array<ContactTrack>> {
     return this.request({
       path: `/company/contacts/${parentId}/tracks`,
@@ -2648,7 +2684,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyContactsByParentIdTracksById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ContactTrack> = {},
   ): Promise<ContactTrack> {
     return this.request({
       path: `/company/contacts/${parentId}/tracks/${id}`,
@@ -2669,7 +2705,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyContactsByParentIdTracksCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/contacts/${parentId}/tracks/count`,
@@ -2680,7 +2716,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyContactsByParentIdTypeAssociations(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ContactContactTypeAssociationContactTypeAssociation> = {},
   ): Promise<Array<ContactContactTypeAssociationContactTypeAssociation>> {
     return this.request({
       path: `/company/contacts/${parentId}/typeAssociations`,
@@ -2703,7 +2739,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyContactsByParentIdTypeAssociationsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ContactContactTypeAssociationContactTypeAssociation> = {},
   ): Promise<ContactContactTypeAssociationContactTypeAssociation> {
     return this.request({
       path: `/company/contacts/${parentId}/typeAssociations/${id}`,
@@ -2748,7 +2784,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyContactsByParentIdTypeAssociationsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/contacts/${parentId}/typeAssociations/count`,
@@ -2757,7 +2793,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyContactsCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyContactsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/contacts/count`,
       method: 'get',
@@ -2765,7 +2801,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyContactsDefault(params: CommonParameters = {}): Promise<Contact> {
+  getCompanyContactsDefault(params: CommonParameters<Contact> = {}): Promise<Contact> {
     return this.request({
       path: `/company/contacts/default`,
       method: 'get',
@@ -2773,7 +2809,9 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyContactsDepartments(params: CommonParameters = {}): Promise<Array<ContactDepartment>> {
+  getCompanyContactsDepartments(
+    params: CommonParameters<ContactDepartment> = {},
+  ): Promise<Array<ContactDepartment>> {
     return this.request({
       path: `/company/contacts/departments`,
       method: 'get',
@@ -2791,7 +2829,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyContactsDepartmentsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ContactDepartment> = {},
   ): Promise<ContactDepartment> {
     return this.request({
       path: `/company/contacts/departments/${id}`,
@@ -2831,7 +2869,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyContactsDepartmentsByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ContactDepartmentInfo> = {},
   ): Promise<ContactDepartmentInfo> {
     return this.request({
       path: `/company/contacts/departments/${id}/info`,
@@ -2842,7 +2880,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyContactsDepartmentsByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/contacts/departments/${id}/usages`,
@@ -2853,7 +2891,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyContactsDepartmentsByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/contacts/departments/${id}/usages/list`,
@@ -2862,7 +2900,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyContactsDepartmentsCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyContactsDepartmentsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/contacts/departments/count`,
       method: 'get',
@@ -2871,7 +2909,7 @@ export class CompanyAPI extends ManageBaseAPI {
   }
 
   getCompanyContactsDepartmentsInfo(
-    params: CommonParameters = {},
+    params: CommonParameters<ContactDepartmentInfo> = {},
   ): Promise<Array<ContactDepartmentInfo>> {
     return this.request({
       path: `/company/contacts/departments/info`,
@@ -2880,7 +2918,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyContactsDepartmentsInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyContactsDepartmentsInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/contacts/departments/info/count`,
       method: 'get',
@@ -2888,7 +2926,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyContactsInfo(params: CommonParameters = {}): Promise<Array<ContactInfo>> {
+  getCompanyContactsInfo(params: CommonParameters<ContactInfo> = {}): Promise<Array<ContactInfo>> {
     return this.request({
       path: `/company/contacts/info`,
       method: 'get',
@@ -2896,7 +2934,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyContactsInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyContactsInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/contacts/info/count`,
       method: 'get',
@@ -2905,7 +2943,7 @@ export class CompanyAPI extends ManageBaseAPI {
   }
 
   getCompanyContactsRelationships(
-    params: CommonParameters = {},
+    params: CommonParameters<ContactRelationship> = {},
   ): Promise<Array<ContactRelationship>> {
     return this.request({
       path: `/company/contacts/relationships`,
@@ -2926,7 +2964,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyContactsRelationshipsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ContactRelationship> = {},
   ): Promise<ContactRelationship> {
     return this.request({
       path: `/company/contacts/relationships/${id}`,
@@ -2964,7 +3002,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyContactsRelationshipsCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyContactsRelationshipsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/contacts/relationships/count`,
       method: 'get',
@@ -2980,7 +3018,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyContactsTypes(params: CommonParameters = {}): Promise<Array<ContactType>> {
+  getCompanyContactsTypes(params: CommonParameters<ContactType> = {}): Promise<Array<ContactType>> {
     return this.request({
       path: `/company/contacts/types`,
       method: 'get',
@@ -2996,7 +3034,10 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyContactsTypesById(id: number, params: CommonParameters = {}): Promise<ContactType> {
+  getCompanyContactsTypesById(
+    id: number,
+    params: CommonParameters<ContactType> = {},
+  ): Promise<ContactType> {
     return this.request({
       path: `/company/contacts/types/${id}`,
       method: 'get',
@@ -3032,7 +3073,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyContactsTypesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ContactTypeInfo> = {},
   ): Promise<ContactTypeInfo> {
     return this.request({
       path: `/company/contacts/types/${id}/info`,
@@ -3041,7 +3082,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyContactsTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyContactsTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/contacts/types/count`,
       method: 'get',
@@ -3049,7 +3090,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyContactsTypesCountInfo(params: CommonParameters = {}): Promise<Count> {
+  getCompanyContactsTypesCountInfo(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/contacts/types/count/info`,
       method: 'get',
@@ -3057,7 +3098,9 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyContactsTypesInfo(params: CommonParameters = {}): Promise<Array<ContactTypeInfo>> {
+  getCompanyContactsTypesInfo(
+    params: CommonParameters<ContactTypeInfo> = {},
+  ): Promise<Array<ContactTypeInfo>> {
     return this.request({
       path: `/company/contacts/types/info`,
       method: 'get',
@@ -3076,7 +3119,7 @@ export class CompanyAPI extends ManageBaseAPI {
   }
 
   getCompanyContactTypeAssociations(
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyContactTypeAssociation> = {},
   ): Promise<Array<CompanyContactTypeAssociation>> {
     return this.request({
       path: `/company/contactTypeAssociations`,
@@ -3097,7 +3140,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyContactTypeAssociationsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyContactTypeAssociation> = {},
   ): Promise<CompanyContactTypeAssociation> {
     return this.request({
       path: `/company/contactTypeAssociations/${id}`,
@@ -3135,7 +3178,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyContactTypeAssociationsCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyContactTypeAssociationsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/contactTypeAssociations/count`,
       method: 'get',
@@ -3143,7 +3186,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyCountries(params: CommonParameters = {}): Promise<Array<Country>> {
+  getCompanyCountries(params: CommonParameters<Country> = {}): Promise<Array<Country>> {
     return this.request({
       path: `/company/countries`,
       method: 'get',
@@ -3159,7 +3202,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyCountriesById(id: number, params: CommonParameters = {}): Promise<Country> {
+  getCompanyCountriesById(id: number, params: CommonParameters<Country> = {}): Promise<Country> {
     return this.request({
       path: `/company/countries/${id}`,
       method: 'get',
@@ -3190,7 +3233,10 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyCountriesByIdInfo(id: number, params: CommonParameters = {}): Promise<CountryInfo> {
+  getCompanyCountriesByIdInfo(
+    id: number,
+    params: CommonParameters<CountryInfo> = {},
+  ): Promise<CountryInfo> {
     return this.request({
       path: `/company/countries/${id}/info`,
       method: 'get',
@@ -3198,7 +3244,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyCountriesCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyCountriesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/countries/count`,
       method: 'get',
@@ -3206,7 +3252,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyCountriesInfo(params: CommonParameters = {}): Promise<Array<CountryInfo>> {
+  getCompanyCountriesInfo(params: CommonParameters<CountryInfo> = {}): Promise<Array<CountryInfo>> {
     return this.request({
       path: `/company/countries/info`,
       method: 'get',
@@ -3214,7 +3260,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyCountriesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyCountriesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/countries/info/count`,
       method: 'get',
@@ -3222,7 +3268,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyEntityTypes(params: CommonParameters = {}): Promise<Array<EntityType>> {
+  getCompanyEntityTypes(params: CommonParameters<EntityType> = {}): Promise<Array<EntityType>> {
     return this.request({
       path: `/company/entityTypes`,
       method: 'get',
@@ -3230,7 +3276,10 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyEntityTypesById(id: number, params: CommonParameters = {}): Promise<EntityType> {
+  getCompanyEntityTypesById(
+    id: number,
+    params: CommonParameters<EntityType> = {},
+  ): Promise<EntityType> {
     return this.request({
       path: `/company/entityTypes/${id}`,
       method: 'get',
@@ -3240,7 +3289,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyEntitytypesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<EntityTypeInfo> = {},
   ): Promise<EntityTypeInfo> {
     return this.request({
       path: `/company/entitytypes/${id}/info`,
@@ -3249,7 +3298,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyEntityTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyEntityTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/entityTypes/count`,
       method: 'get',
@@ -3257,7 +3306,9 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyEntitytypesInfo(params: CommonParameters = {}): Promise<Array<EntityTypeInfo>> {
+  getCompanyEntitytypesInfo(
+    params: CommonParameters<EntityTypeInfo> = {},
+  ): Promise<Array<EntityTypeInfo>> {
     return this.request({
       path: `/company/entitytypes/info`,
       method: 'get',
@@ -3265,7 +3316,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyEntityTypesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyEntityTypesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/entityTypes/info/count`,
       method: 'get',
@@ -3273,7 +3324,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyExpenseTypesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyExpenseTypesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/expenseTypes/info/count`,
       method: 'get',
@@ -3281,7 +3332,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyM365contact(params: CommonParameters = {}): Promise<Array<M365Contact>> {
+  getCompanyM365contact(params: CommonParameters<M365Contact> = {}): Promise<Array<M365Contact>> {
     return this.request({
       path: `/company/m365contact`,
       method: 'get',
@@ -3289,7 +3340,10 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyM365contactById(id: number, params: CommonParameters = {}): Promise<M365Contact> {
+  getCompanyM365contactById(
+    id: number,
+    params: CommonParameters<M365Contact> = {},
+  ): Promise<M365Contact> {
     return this.request({
       path: `/company/m365contact/${id}`,
       method: 'get',
@@ -3297,7 +3351,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyM365contactCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyM365contactCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/m365contact/count`,
       method: 'get',
@@ -3307,7 +3361,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyM365contactsyncByIdProperty(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<M365ContactSyncProperty> = {},
   ): Promise<M365ContactSyncProperty> {
     return this.request({
       path: `/company/m365contactsync/${id}/property`,
@@ -3333,7 +3387,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyM365contactsyncPropertyCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyM365contactsyncPropertyCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/m365contactsync/property/count`,
       method: 'get',
@@ -3342,7 +3396,7 @@ export class CompanyAPI extends ManageBaseAPI {
   }
 
   getCompanyM365contactsyncPropertyExcluded(
-    params: CommonParameters = {},
+    params: CommonParameters<M365ContactSyncProperty> = {},
   ): Promise<Array<M365ContactSyncProperty>> {
     return this.request({
       path: `/company/m365contactsync/property/excluded`,
@@ -3352,7 +3406,7 @@ export class CompanyAPI extends ManageBaseAPI {
   }
 
   getCompanyM365contactsyncPropertyIncluded(
-    params: CommonParameters = {},
+    params: CommonParameters<M365ContactSyncProperty> = {},
   ): Promise<Array<M365ContactSyncProperty>> {
     return this.request({
       path: `/company/m365contactsync/property/included`,
@@ -3362,7 +3416,7 @@ export class CompanyAPI extends ManageBaseAPI {
   }
 
   getCompanyManagedDevicesIntegrations(
-    params: CommonParameters = {},
+    params: CommonParameters<ManagedDevicesIntegration> = {},
   ): Promise<Array<ManagedDevicesIntegration>> {
     return this.request({
       path: `/company/managedDevicesIntegrations`,
@@ -3383,7 +3437,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyManagedDevicesIntegrationsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ManagedDevicesIntegration> = {},
   ): Promise<ManagedDevicesIntegration> {
     return this.request({
       path: `/company/managedDevicesIntegrations/${id}`,
@@ -3423,7 +3477,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyManagedDevicesIntegrationsByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ManagedDevicesIntegrationInfo> = {},
   ): Promise<ManagedDevicesIntegrationInfo> {
     return this.request({
       path: `/company/managedDevicesIntegrations/${id}/info`,
@@ -3434,7 +3488,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyManagedDevicesIntegrationsByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/managedDevicesIntegrations/${id}/usages`,
@@ -3445,7 +3499,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyManagedDevicesIntegrationsByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/managedDevicesIntegrations/${id}/usages/list`,
@@ -3456,7 +3510,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyManagedDevicesIntegrationsByParentIdCrossReferences(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ManagedDevicesIntegrationCrossReference> = {},
   ): Promise<Array<ManagedDevicesIntegrationCrossReference>> {
     return this.request({
       path: `/company/managedDevicesIntegrations/${parentId}/crossReferences`,
@@ -3479,7 +3533,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyManagedDevicesIntegrationsByParentIdCrossReferencesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ManagedDevicesIntegrationCrossReference> = {},
   ): Promise<ManagedDevicesIntegrationCrossReference> {
     return this.request({
       path: `/company/managedDevicesIntegrations/${parentId}/crossReferences/${id}`,
@@ -3524,7 +3578,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyManagedDevicesIntegrationsByParentIdCrossReferencesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/managedDevicesIntegrations/${parentId}/crossReferences/count`,
@@ -3535,7 +3589,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyManagedDevicesIntegrationsByParentIdLogins(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ManagedDevicesIntegrationLogin> = {},
   ): Promise<Array<ManagedDevicesIntegrationLogin>> {
     return this.request({
       path: `/company/managedDevicesIntegrations/${parentId}/logins`,
@@ -3558,7 +3612,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyManagedDevicesIntegrationsByParentIdLoginsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ManagedDevicesIntegrationLogin> = {},
   ): Promise<ManagedDevicesIntegrationLogin> {
     return this.request({
       path: `/company/managedDevicesIntegrations/${parentId}/logins/${id}`,
@@ -3603,7 +3657,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyManagedDevicesIntegrationsByParentIdLoginsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/managedDevicesIntegrations/${parentId}/logins/count`,
@@ -3614,7 +3668,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyManagedDevicesIntegrationsByParentIdNotifications(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ManagedDevicesIntegrationNotification> = {},
   ): Promise<Array<ManagedDevicesIntegrationNotification>> {
     return this.request({
       path: `/company/managedDevicesIntegrations/${parentId}/notifications`,
@@ -3637,7 +3691,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyManagedDevicesIntegrationsByParentIdNotificationsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ManagedDevicesIntegrationNotification> = {},
   ): Promise<ManagedDevicesIntegrationNotification> {
     return this.request({
       path: `/company/managedDevicesIntegrations/${parentId}/notifications/${id}`,
@@ -3682,7 +3736,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyManagedDevicesIntegrationsByParentIdNotificationsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/managedDevicesIntegrations/${parentId}/notifications/count`,
@@ -3691,7 +3745,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyManagedDevicesIntegrationsCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyManagedDevicesIntegrationsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/managedDevicesIntegrations/count`,
       method: 'get',
@@ -3700,7 +3754,7 @@ export class CompanyAPI extends ManageBaseAPI {
   }
 
   getCompanyManagedDevicesIntegrationsInfo(
-    params: CommonParameters = {},
+    params: CommonParameters<ManagedDevicesIntegrationInfo> = {},
   ): Promise<Array<ManagedDevicesIntegrationInfo>> {
     return this.request({
       path: `/company/managedDevicesIntegrations/info`,
@@ -3709,7 +3763,9 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyManagedDevicesIntegrationsInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyManagedDevicesIntegrationsInfoCount(
+    params: CommonParameters<Count> = {},
+  ): Promise<Count> {
     return this.request({
       path: `/company/managedDevicesIntegrations/info/count`,
       method: 'get',
@@ -3717,7 +3773,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyManagement(params: CommonParameters = {}): Promise<Array<Management>> {
+  getCompanyManagement(params: CommonParameters<Management> = {}): Promise<Array<Management>> {
     return this.request({
       path: `/company/management`,
       method: 'get',
@@ -3725,7 +3781,10 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyManagementById(id: number, params: CommonParameters = {}): Promise<Management> {
+  getCompanyManagementById(
+    id: number,
+    params: CommonParameters<Management> = {},
+  ): Promise<Management> {
     return this.request({
       path: `/company/management/${id}`,
       method: 'get',
@@ -3761,7 +3820,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyManagementByIdLogDownload(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<OctetStreamResponse> = {},
   ): Promise<OctetStreamResponse> {
     return this.request({
       path: `/company/management/${id}/log/download`,
@@ -3772,7 +3831,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyManagementByIdLogs(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ManagementLogDocumentInfo> = {},
   ): Promise<Array<ManagementLogDocumentInfo>> {
     return this.request({
       path: `/company/management/${id}/logs`,
@@ -3783,7 +3842,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyManagementByParentIdManagementReportNotifications(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ManagementReportNotification> = {},
   ): Promise<Array<ManagementReportNotification>> {
     return this.request({
       path: `/company/management/${parentId}/managementReportNotifications`,
@@ -3806,7 +3865,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyManagementByParentIdManagementReportNotificationsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ManagementReportNotification> = {},
   ): Promise<ManagementReportNotification> {
     return this.request({
       path: `/company/management/${parentId}/managementReportNotifications/${id}`,
@@ -3851,7 +3910,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyManagementByParentIdManagementReportNotificationsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/management/${parentId}/managementReportNotifications/count`,
@@ -3860,7 +3919,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyManagementCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyManagementCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/management/count`,
       method: 'get',
@@ -3868,7 +3927,9 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyManagementBackups(params: CommonParameters = {}): Promise<Array<ManagementBackup>> {
+  getCompanyManagementBackups(
+    params: CommonParameters<ManagementBackup> = {},
+  ): Promise<Array<ManagementBackup>> {
     return this.request({
       path: `/company/managementBackups`,
       method: 'get',
@@ -3886,7 +3947,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyManagementBackupsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ManagementBackup> = {},
   ): Promise<ManagementBackup> {
     return this.request({
       path: `/company/managementBackups/${id}`,
@@ -3924,7 +3985,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyManagementBackupsCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyManagementBackupsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/managementBackups/count`,
       method: 'get',
@@ -3933,7 +3994,7 @@ export class CompanyAPI extends ManageBaseAPI {
   }
 
   getCompanyManagementItSolutions(
-    params: CommonParameters = {},
+    params: CommonParameters<ManagementItSolution> = {},
   ): Promise<Array<ManagementItSolution>> {
     return this.request({
       path: `/company/managementItSolutions`,
@@ -3954,7 +4015,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyManagementItSolutionsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ManagementItSolution> = {},
   ): Promise<ManagementItSolution> {
     return this.request({
       path: `/company/managementItSolutions/${id}`,
@@ -3994,7 +4055,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyManagementItSolutionsByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/managementItSolutions/${id}/usages`,
@@ -4005,7 +4066,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyManagementItSolutionsByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/managementItSolutions/${id}/usages/list`,
@@ -4016,7 +4077,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyManagementItSolutionsByParentIdManagementProducts(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ManagementItSolutionAgreementInterfaceParameter> = {},
   ): Promise<Array<ManagementItSolutionAgreementInterfaceParameter>> {
     return this.request({
       path: `/company/managementItSolutions/${parentId}/managementProducts`,
@@ -4039,7 +4100,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyManagementItSolutionsByParentIdManagementProductsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ManagementItSolutionAgreementInterfaceParameter> = {},
   ): Promise<ManagementItSolutionAgreementInterfaceParameter> {
     return this.request({
       path: `/company/managementItSolutions/${parentId}/managementProducts/${id}`,
@@ -4084,7 +4145,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyManagementItSolutionsByParentIdManagementProductsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/managementItSolutions/${parentId}/managementProducts/count`,
@@ -4093,7 +4154,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyManagementItSolutionsCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyManagementItSolutionsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/managementItSolutions/count`,
       method: 'get',
@@ -4101,7 +4162,9 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyMarketDescriptions(params: CommonParameters = {}): Promise<Array<MarketDescription>> {
+  getCompanyMarketDescriptions(
+    params: CommonParameters<MarketDescription> = {},
+  ): Promise<Array<MarketDescription>> {
     return this.request({
       path: `/company/marketDescriptions`,
       method: 'get',
@@ -4119,7 +4182,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyMarketDescriptionsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MarketDescription> = {},
   ): Promise<MarketDescription> {
     return this.request({
       path: `/company/marketDescriptions/${id}`,
@@ -4159,7 +4222,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyMarketDescriptionsByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MarketDescriptionInfo> = {},
   ): Promise<MarketDescriptionInfo> {
     return this.request({
       path: `/company/marketDescriptions/${id}/info`,
@@ -4170,7 +4233,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyMarketDescriptionsByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/marketDescriptions/${id}/usages`,
@@ -4181,7 +4244,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyMarketDescriptionsByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/marketDescriptions/${id}/usages/list`,
@@ -4190,7 +4253,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyMarketDescriptionsCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyMarketDescriptionsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/marketDescriptions/count`,
       method: 'get',
@@ -4199,7 +4262,7 @@ export class CompanyAPI extends ManageBaseAPI {
   }
 
   getCompanyMarketDescriptionsInfo(
-    params: CommonParameters = {},
+    params: CommonParameters<MarketDescriptionInfo> = {},
   ): Promise<Array<MarketDescriptionInfo>> {
     return this.request({
       path: `/company/marketDescriptions/info`,
@@ -4208,7 +4271,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyMarketDescriptionsInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyMarketDescriptionsInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/marketDescriptions/info/count`,
       method: 'get',
@@ -4216,7 +4279,9 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyNoteTypes(params: CommonParameters = {}): Promise<Array<CompanyNoteType>> {
+  getCompanyNoteTypes(
+    params: CommonParameters<CompanyNoteType> = {},
+  ): Promise<Array<CompanyNoteType>> {
     return this.request({
       path: `/company/noteTypes`,
       method: 'get',
@@ -4232,7 +4297,10 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyNoteTypesById(id: number, params: CommonParameters = {}): Promise<CompanyNoteType> {
+  getCompanyNoteTypesById(
+    id: number,
+    params: CommonParameters<CompanyNoteType> = {},
+  ): Promise<CompanyNoteType> {
     return this.request({
       path: `/company/noteTypes/${id}`,
       method: 'get',
@@ -4268,7 +4336,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyNoteTypesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CompanyNoteTypeInfo> = {},
   ): Promise<CompanyNoteTypeInfo> {
     return this.request({
       path: `/company/noteTypes/${id}/info`,
@@ -4277,7 +4345,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyNoteTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyNoteTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/noteTypes/count`,
       method: 'get',
@@ -4285,7 +4353,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyNoteTypesCountInfo(params: CommonParameters = {}): Promise<Count> {
+  getCompanyNoteTypesCountInfo(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/noteTypes/count/info`,
       method: 'get',
@@ -4293,7 +4361,9 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyNoteTypesInfo(params: CommonParameters = {}): Promise<Array<CompanyNoteTypeInfo>> {
+  getCompanyNoteTypesInfo(
+    params: CommonParameters<CompanyNoteTypeInfo> = {},
+  ): Promise<Array<CompanyNoteTypeInfo>> {
     return this.request({
       path: `/company/noteTypes/info`,
       method: 'get',
@@ -4301,7 +4371,9 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyOwnershipTypes(params: CommonParameters = {}): Promise<Array<OwnershipType>> {
+  getCompanyOwnershipTypes(
+    params: CommonParameters<OwnershipType> = {},
+  ): Promise<Array<OwnershipType>> {
     return this.request({
       path: `/company/ownershipTypes`,
       method: 'get',
@@ -4317,7 +4389,10 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyOwnershipTypesById(id: number, params: CommonParameters = {}): Promise<OwnershipType> {
+  getCompanyOwnershipTypesById(
+    id: number,
+    params: CommonParameters<OwnershipType> = {},
+  ): Promise<OwnershipType> {
     return this.request({
       path: `/company/ownershipTypes/${id}`,
       method: 'get',
@@ -4353,7 +4428,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyOwnershipTypesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<OwnershipTypeInfo> = {},
   ): Promise<OwnershipTypeInfo> {
     return this.request({
       path: `/company/ownershipTypes/${id}/info`,
@@ -4362,7 +4437,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyOwnershipTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyOwnershipTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/ownershipTypes/count`,
       method: 'get',
@@ -4370,7 +4445,9 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyOwnershipTypesInfo(params: CommonParameters = {}): Promise<Array<OwnershipTypeInfo>> {
+  getCompanyOwnershipTypesInfo(
+    params: CommonParameters<OwnershipTypeInfo> = {},
+  ): Promise<Array<OwnershipTypeInfo>> {
     return this.request({
       path: `/company/ownershipTypes/info`,
       method: 'get',
@@ -4378,7 +4455,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyOwnershipTypesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyOwnershipTypesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/ownershipTypes/info/count`,
       method: 'get',
@@ -4386,7 +4463,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyPaymentTypesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyPaymentTypesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/paymentTypes/info/count`,
       method: 'get',
@@ -4395,7 +4472,7 @@ export class CompanyAPI extends ManageBaseAPI {
   }
 
   getCompanyPortalConfigurations(
-    params: CommonParameters = {},
+    params: CommonParameters<PortalConfiguration> = {},
   ): Promise<Array<PortalConfiguration>> {
     return this.request({
       path: `/company/portalConfigurations`,
@@ -4416,7 +4493,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyPortalConfigurationsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PortalConfiguration> = {},
   ): Promise<PortalConfiguration> {
     return this.request({
       path: `/company/portalConfigurations/${id}`,
@@ -4456,7 +4533,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyPortalConfigurationsByParentIdInvoiceSetups(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PortalConfigurationInvoiceSetup> = {},
   ): Promise<Array<PortalConfigurationInvoiceSetup>> {
     return this.request({
       path: `/company/portalConfigurations/${parentId}/invoiceSetups`,
@@ -4468,7 +4545,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyPortalConfigurationsByParentIdInvoiceSetupsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PortalConfigurationInvoiceSetup> = {},
   ): Promise<PortalConfigurationInvoiceSetup> {
     return this.request({
       path: `/company/portalConfigurations/${parentId}/invoiceSetups/${id}`,
@@ -4515,7 +4592,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyPortalConfigurationsByParentIdInvoiceSetupsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/portalConfigurations/${parentId}/invoiceSetups/count`,
@@ -4526,7 +4603,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyPortalConfigurationsByParentIdOpportunitySetups(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PortalConfigurationOpportunitySetup> = {},
   ): Promise<Array<PortalConfigurationOpportunitySetup>> {
     return this.request({
       path: `/company/portalConfigurations/${parentId}/opportunitySetups`,
@@ -4560,7 +4637,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyPortalConfigurationsByParentIdOpportunitySetupsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PortalConfigurationOpportunitySetup> = {},
   ): Promise<PortalConfigurationOpportunitySetup> {
     return this.request({
       path: `/company/portalConfigurations/${parentId}/opportunitySetups/${id}`,
@@ -4595,7 +4672,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyPortalConfigurationsByParentIdPasswordEmailSetups(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PortalConfigurationPasswordEmailSetup> = {},
   ): Promise<Array<PortalConfigurationPasswordEmailSetup>> {
     return this.request({
       path: `/company/portalConfigurations/${parentId}/passwordEmailSetups`,
@@ -4607,7 +4684,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyPortalConfigurationsByParentIdPasswordEmailSetupsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PortalConfigurationPasswordEmailSetup> = {},
   ): Promise<PortalConfigurationPasswordEmailSetup> {
     return this.request({
       path: `/company/portalConfigurations/${parentId}/passwordEmailSetups/${id}`,
@@ -4642,7 +4719,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyPortalConfigurationsByParentIdProjectSetups(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PortalConfigurationProjectSetup> = {},
   ): Promise<Array<PortalConfigurationProjectSetup>> {
     return this.request({
       path: `/company/portalConfigurations/${parentId}/projectSetups`,
@@ -4654,7 +4731,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyPortalConfigurationsByParentIdProjectSetupsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PortalConfigurationProjectSetup> = {},
   ): Promise<PortalConfigurationProjectSetup> {
     return this.request({
       path: `/company/portalConfigurations/${parentId}/projectSetups/${id}`,
@@ -4689,7 +4766,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyPortalConfigurationsByParentIdProjectSetupsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/portalConfigurations/${parentId}/projectSetups/count`,
@@ -4700,7 +4777,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyPortalConfigurationsByParentIdServiceSetups(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PortalConfigurationServiceSetup> = {},
   ): Promise<Array<PortalConfigurationServiceSetup>> {
     return this.request({
       path: `/company/portalConfigurations/${parentId}/serviceSetups`,
@@ -4712,7 +4789,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyPortalConfigurationsByParentIdServiceSetupsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PortalConfigurationServiceSetup> = {},
   ): Promise<PortalConfigurationServiceSetup> {
     return this.request({
       path: `/company/portalConfigurations/${parentId}/serviceSetups/${id}`,
@@ -4747,7 +4824,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyPortalConfigurationsByParentIdServiceSetupsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/portalConfigurations/${parentId}/serviceSetups/count`,
@@ -4764,7 +4841,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyPortalConfigurationsCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyPortalConfigurationsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/portalConfigurations/count`,
       method: 'get',
@@ -4773,7 +4850,7 @@ export class CompanyAPI extends ManageBaseAPI {
   }
 
   getCompanyPortalConfigurationsInvoiceSetupPaymentProcessors(
-    params: CommonParameters = {},
+    params: CommonParameters<PortalConfigurationPaymentProcessor> = {},
   ): Promise<Array<PortalConfigurationPaymentProcessor>> {
     return this.request({
       path: `/company/portalConfigurations/invoiceSetup/paymentProcessors`,
@@ -4784,7 +4861,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyPortalConfigurationsInvoiceSetupPaymentProcessorsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PortalConfigurationPaymentProcessor> = {},
   ): Promise<PortalConfigurationPaymentProcessor> {
     return this.request({
       path: `/company/portalConfigurations/invoiceSetup/paymentProcessors/${id}`,
@@ -4794,7 +4871,7 @@ export class CompanyAPI extends ManageBaseAPI {
   }
 
   getCompanyPortalConfigurationsInvoiceSetupPaymentProcessorsCount(
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/portalConfigurations/invoiceSetup/paymentProcessors/count`,
@@ -4804,7 +4881,7 @@ export class CompanyAPI extends ManageBaseAPI {
   }
 
   getCompanyPortalSecurityLevels(
-    params: CommonParameters = {},
+    params: CommonParameters<PortalSecurityLevel> = {},
   ): Promise<Array<PortalSecurityLevel>> {
     return this.request({
       path: `/company/portalSecurityLevels`,
@@ -4815,7 +4892,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyPortalSecurityLevelsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PortalSecurityLevel> = {},
   ): Promise<PortalSecurityLevel> {
     return this.request({
       path: `/company/portalSecurityLevels/${id}`,
@@ -4846,7 +4923,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyPortalSecurityLevelsCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyPortalSecurityLevelsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/portalSecurityLevels/count`,
       method: 'get',
@@ -4855,7 +4932,7 @@ export class CompanyAPI extends ManageBaseAPI {
   }
 
   getCompanyPortalSecuritySettings(
-    params: CommonParameters = {},
+    params: CommonParameters<PortalSecuritySetting> = {},
   ): Promise<Array<PortalSecuritySetting>> {
     return this.request({
       path: `/company/portalSecuritySettings`,
@@ -4866,7 +4943,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyPortalSecuritySettingsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PortalSecuritySetting> = {},
   ): Promise<PortalSecuritySetting> {
     return this.request({
       path: `/company/portalSecuritySettings/${id}`,
@@ -4897,7 +4974,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyPortalSecuritySettingsCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyPortalSecuritySettingsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/portalSecuritySettings/count`,
       method: 'get',
@@ -4905,7 +4982,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyStates(params: CommonParameters = {}): Promise<Array<State>> {
+  getCompanyStates(params: CommonParameters<State> = {}): Promise<Array<State>> {
     return this.request({
       path: `/company/states`,
       method: 'get',
@@ -4921,7 +4998,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyStatesById(id: number, params: CommonParameters = {}): Promise<State> {
+  getCompanyStatesById(id: number, params: CommonParameters<State> = {}): Promise<State> {
     return this.request({
       path: `/company/states/${id}`,
       method: 'get',
@@ -4952,7 +5029,10 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyStatesByIdInfo(id: number, params: CommonParameters = {}): Promise<StateInfo> {
+  getCompanyStatesByIdInfo(
+    id: number,
+    params: CommonParameters<StateInfo> = {},
+  ): Promise<StateInfo> {
     return this.request({
       path: `/company/states/${id}/info`,
       method: 'get',
@@ -4960,7 +5040,10 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyStatesByIdUsages(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getCompanyStatesByIdUsages(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/states/${id}/usages`,
       method: 'get',
@@ -4968,7 +5051,10 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyStatesByIdUsagesList(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getCompanyStatesByIdUsagesList(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/states/${id}/usages/list`,
       method: 'get',
@@ -4976,7 +5062,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyStatesCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyStatesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/states/count`,
       method: 'get',
@@ -4984,7 +5070,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyStatesInfo(params: CommonParameters = {}): Promise<Array<StateInfo>> {
+  getCompanyStatesInfo(params: CommonParameters<StateInfo> = {}): Promise<Array<StateInfo>> {
     return this.request({
       path: `/company/states/info`,
       method: 'get',
@@ -4992,7 +5078,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyStatesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyStatesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/states/info/count`,
       method: 'get',
@@ -5000,7 +5086,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyTeamRoles(params: CommonParameters = {}): Promise<Array<TeamRole>> {
+  getCompanyTeamRoles(params: CommonParameters<TeamRole> = {}): Promise<Array<TeamRole>> {
     return this.request({
       path: `/company/teamRoles`,
       method: 'get',
@@ -5016,7 +5102,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyTeamRolesById(id: number, params: CommonParameters = {}): Promise<TeamRole> {
+  getCompanyTeamRolesById(id: number, params: CommonParameters<TeamRole> = {}): Promise<TeamRole> {
     return this.request({
       path: `/company/teamRoles/${id}`,
       method: 'get',
@@ -5047,7 +5133,10 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyTeamRolesByIdInfo(id: number, params: CommonParameters = {}): Promise<TeamRoleInfo> {
+  getCompanyTeamRolesByIdInfo(
+    id: number,
+    params: CommonParameters<TeamRoleInfo> = {},
+  ): Promise<TeamRoleInfo> {
     return this.request({
       path: `/company/teamRoles/${id}/info`,
       method: 'get',
@@ -5055,7 +5144,10 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyTeamRolesByIdUsages(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getCompanyTeamRolesByIdUsages(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/teamRoles/${id}/usages`,
       method: 'get',
@@ -5065,7 +5157,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyTeamRolesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/company/teamRoles/${id}/usages/list`,
@@ -5074,7 +5166,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyTeamRolesCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyTeamRolesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/teamRoles/count`,
       method: 'get',
@@ -5082,7 +5174,9 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyTeamRolesInfo(params: CommonParameters = {}): Promise<Array<TeamRoleInfo>> {
+  getCompanyTeamRolesInfo(
+    params: CommonParameters<TeamRoleInfo> = {},
+  ): Promise<Array<TeamRoleInfo>> {
     return this.request({
       path: `/company/teamRoles/info`,
       method: 'get',
@@ -5090,7 +5184,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyTeamRolesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyTeamRolesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/teamRoles/info/count`,
       method: 'get',
@@ -5098,7 +5192,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyTracks(params: CommonParameters = {}): Promise<Array<Track>> {
+  getCompanyTracks(params: CommonParameters<Track> = {}): Promise<Array<Track>> {
     return this.request({
       path: `/company/tracks`,
       method: 'get',
@@ -5114,7 +5208,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyTracksById(id: number, params: CommonParameters = {}): Promise<Track> {
+  getCompanyTracksById(id: number, params: CommonParameters<Track> = {}): Promise<Track> {
     return this.request({
       path: `/company/tracks/${id}`,
       method: 'get',
@@ -5147,7 +5241,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyTracksByParentIdActions(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TrackAction> = {},
   ): Promise<Array<TrackAction>> {
     return this.request({
       path: `/company/tracks/${parentId}/actions`,
@@ -5170,7 +5264,7 @@ export class CompanyAPI extends ManageBaseAPI {
   getCompanyTracksByParentIdActionsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TrackAction> = {},
   ): Promise<TrackAction> {
     return this.request({
       path: `/company/tracks/${parentId}/actions/${id}`,
@@ -5210,7 +5304,7 @@ export class CompanyAPI extends ManageBaseAPI {
 
   getCompanyTracksByParentIdActionsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/company/tracks/${parentId}/actions/count`,
@@ -5219,7 +5313,7 @@ export class CompanyAPI extends ManageBaseAPI {
     })
   }
 
-  getCompanyTracksCount(params: CommonParameters = {}): Promise<Count> {
+  getCompanyTracksCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/company/tracks/count`,
       method: 'get',

--- a/src/Manage/ConfigurationsAPI.ts
+++ b/src/Manage/ConfigurationsAPI.ts
@@ -21,7 +21,7 @@ export class ConfigurationsAPI extends ManageBaseAPI {
     grandparentId: number,
     parentId: number,
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ConfigurationTypeQuestionInfo> = {},
   ): Promise<ConfigurationTypeQuestionInfo> {
     return this.request({
       path: `/configurations/types/${grandparentId}/questions/${parentId}/values/${id}/info`,
@@ -33,7 +33,7 @@ export class ConfigurationsAPI extends ManageBaseAPI {
   getConfigurationsTypesByGrandparentIdQuestionsByParentIdValuesInfo(
     grandparentId: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ConfigurationTypeQuestionValueInfo> = {},
   ): Promise<Array<ConfigurationTypeQuestionValueInfo>> {
     return this.request({
       path: `/configurations/types/${grandparentId}/questions/${parentId}/values/info`,
@@ -45,7 +45,7 @@ export class ConfigurationsAPI extends ManageBaseAPI {
   getConfigurationsTypesByGrandparentIdQuestionsByParentIdValuesInfoCount(
     grandparentId: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/configurations/types/${grandparentId}/questions/${parentId}/values/info/count`,
@@ -57,7 +57,7 @@ export class ConfigurationsAPI extends ManageBaseAPI {
   getConfigurationsTypesByParentIdQuestionsByIdInfo(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ConfigurationTypeQuestionInfo> = {},
   ): Promise<ConfigurationTypeQuestionInfo> {
     return this.request({
       path: `/configurations/types/${parentId}/questions/${id}/info`,
@@ -68,7 +68,7 @@ export class ConfigurationsAPI extends ManageBaseAPI {
 
   getConfigurationsTypesByParentIdQuestionsInfo(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ConfigurationTypeQuestionInfo> = {},
   ): Promise<Array<ConfigurationTypeQuestionInfo>> {
     return this.request({
       path: `/configurations/types/${parentId}/questions/info`,
@@ -79,7 +79,7 @@ export class ConfigurationsAPI extends ManageBaseAPI {
 
   getConfigurationsTypesByParentIdQuestionsInfoCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/configurations/types/${parentId}/questions/info/count`,
@@ -88,7 +88,9 @@ export class ConfigurationsAPI extends ManageBaseAPI {
     })
   }
 
-  getConfigurationsTypesInfo(params: CommonParameters = {}): Promise<Array<ConfigurationTypeInfo>> {
+  getConfigurationsTypesInfo(
+    params: CommonParameters<ConfigurationTypeInfo> = {},
+  ): Promise<Array<ConfigurationTypeInfo>> {
     return this.request({
       path: `/configurations/types/info`,
       method: 'get',
@@ -96,7 +98,7 @@ export class ConfigurationsAPI extends ManageBaseAPI {
     })
   }
 
-  getConfigurationsTypesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getConfigurationsTypesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/configurations/types/info/count`,
       method: 'get',

--- a/src/Manage/ExpenseAPI.ts
+++ b/src/Manage/ExpenseAPI.ts
@@ -38,7 +38,9 @@ export type SuccessResponse = schemas['SuccessResponse']
  * @public
  */
 export class ExpenseAPI extends ManageBaseAPI {
-  getExpenseClassifications(params: CommonParameters = {}): Promise<Array<Classification>> {
+  getExpenseClassifications(
+    params: CommonParameters<Classification> = {},
+  ): Promise<Array<Classification>> {
     return this.request({
       path: `/expense/classifications`,
       method: 'get',
@@ -48,7 +50,7 @@ export class ExpenseAPI extends ManageBaseAPI {
 
   getExpenseClassificationsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Classification> = {},
   ): Promise<Classification> {
     return this.request({
       path: `/expense/classifications/${id}`,
@@ -57,7 +59,7 @@ export class ExpenseAPI extends ManageBaseAPI {
     })
   }
 
-  getExpenseClassificationsCount(params: CommonParameters = {}): Promise<Count> {
+  getExpenseClassificationsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/expense/classifications/count`,
       method: 'get',
@@ -65,7 +67,7 @@ export class ExpenseAPI extends ManageBaseAPI {
     })
   }
 
-  getExpenseEntries(params: CommonParameters = {}): Promise<Array<ExpenseEntry>> {
+  getExpenseEntries(params: CommonParameters<ExpenseEntry> = {}): Promise<Array<ExpenseEntry>> {
     return this.request({
       path: `/expense/entries`,
       method: 'get',
@@ -81,7 +83,10 @@ export class ExpenseAPI extends ManageBaseAPI {
     })
   }
 
-  getExpenseEntriesById(id: number, params: CommonParameters = {}): Promise<ExpenseEntry> {
+  getExpenseEntriesById(
+    id: number,
+    params: CommonParameters<ExpenseEntry> = {},
+  ): Promise<ExpenseEntry> {
     return this.request({
       path: `/expense/entries/${id}`,
       method: 'get',
@@ -117,7 +122,7 @@ export class ExpenseAPI extends ManageBaseAPI {
 
   getExpenseEntriesByParentIdAudits(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ExpenseEntryAudit> = {},
   ): Promise<Array<ExpenseEntryAudit>> {
     return this.request({
       path: `/expense/entries/${parentId}/audits`,
@@ -129,7 +134,7 @@ export class ExpenseAPI extends ManageBaseAPI {
   getExpenseEntriesByParentIdAuditsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ExpenseEntryAudit> = {},
   ): Promise<ExpenseEntryAudit> {
     return this.request({
       path: `/expense/entries/${parentId}/audits/${id}`,
@@ -140,7 +145,7 @@ export class ExpenseAPI extends ManageBaseAPI {
 
   getExpenseEntriesByParentIdAuditsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/expense/entries/${parentId}/audits/count`,
@@ -149,7 +154,7 @@ export class ExpenseAPI extends ManageBaseAPI {
     })
   }
 
-  getExpenseEntriesCount(params: CommonParameters = {}): Promise<Count> {
+  getExpenseEntriesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/expense/entries/count`,
       method: 'get',
@@ -157,7 +162,9 @@ export class ExpenseAPI extends ManageBaseAPI {
     })
   }
 
-  getExpenseInfoTaxTypes(params: CommonParameters = {}): Promise<Array<ExpenseTaxTypeInfo>> {
+  getExpenseInfoTaxTypes(
+    params: CommonParameters<ExpenseTaxTypeInfo> = {},
+  ): Promise<Array<ExpenseTaxTypeInfo>> {
     return this.request({
       path: `/expense/info/taxTypes`,
       method: 'get',
@@ -167,7 +174,7 @@ export class ExpenseAPI extends ManageBaseAPI {
 
   getExpenseInfoTaxTypesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ExpenseTaxTypeInfo> = {},
   ): Promise<ExpenseTaxTypeInfo> {
     return this.request({
       path: `/expense/info/taxTypes/${id}`,
@@ -176,7 +183,7 @@ export class ExpenseAPI extends ManageBaseAPI {
     })
   }
 
-  getExpenseInfoTaxTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getExpenseInfoTaxTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/expense/info/taxTypes/count`,
       method: 'get',
@@ -184,7 +191,7 @@ export class ExpenseAPI extends ManageBaseAPI {
     })
   }
 
-  getExpensePaymentTypes(params: CommonParameters = {}): Promise<Array<PaymentType>> {
+  getExpensePaymentTypes(params: CommonParameters<PaymentType> = {}): Promise<Array<PaymentType>> {
     return this.request({
       path: `/expense/paymentTypes`,
       method: 'get',
@@ -200,7 +207,10 @@ export class ExpenseAPI extends ManageBaseAPI {
     })
   }
 
-  getExpensePaymentTypesById(id: number, params: CommonParameters = {}): Promise<PaymentType> {
+  getExpensePaymentTypesById(
+    id: number,
+    params: CommonParameters<PaymentType> = {},
+  ): Promise<PaymentType> {
     return this.request({
       path: `/expense/paymentTypes/${id}`,
       method: 'get',
@@ -236,7 +246,7 @@ export class ExpenseAPI extends ManageBaseAPI {
 
   getExpensePaymentTypesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PaymentTypeInfo> = {},
   ): Promise<PaymentTypeInfo> {
     return this.request({
       path: `/expense/paymentTypes/${id}/info`,
@@ -245,7 +255,7 @@ export class ExpenseAPI extends ManageBaseAPI {
     })
   }
 
-  getExpensePaymentTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getExpensePaymentTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/expense/paymentTypes/count`,
       method: 'get',
@@ -253,7 +263,9 @@ export class ExpenseAPI extends ManageBaseAPI {
     })
   }
 
-  getExpensePaymentTypesInfo(params: CommonParameters = {}): Promise<Array<PaymentTypeInfo>> {
+  getExpensePaymentTypesInfo(
+    params: CommonParameters<PaymentTypeInfo> = {},
+  ): Promise<Array<PaymentTypeInfo>> {
     return this.request({
       path: `/expense/paymentTypes/info`,
       method: 'get',
@@ -261,7 +273,7 @@ export class ExpenseAPI extends ManageBaseAPI {
     })
   }
 
-  getExpenseReports(params: CommonParameters = {}): Promise<Array<ExpenseReport>> {
+  getExpenseReports(params: CommonParameters<ExpenseReport> = {}): Promise<Array<ExpenseReport>> {
     return this.request({
       path: `/expense/reports`,
       method: 'get',
@@ -269,7 +281,10 @@ export class ExpenseAPI extends ManageBaseAPI {
     })
   }
 
-  getExpenseReportsById(id: number, params: CommonParameters = {}): Promise<ExpenseReport> {
+  getExpenseReportsById(
+    id: number,
+    params: CommonParameters<ExpenseReport> = {},
+  ): Promise<ExpenseReport> {
     return this.request({
       path: `/expense/reports/${id}`,
       method: 'get',
@@ -311,7 +326,7 @@ export class ExpenseAPI extends ManageBaseAPI {
 
   getExpenseReportsByParentIdAudits(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ExpenseReportAudit> = {},
   ): Promise<Array<ExpenseReportAudit>> {
     return this.request({
       path: `/expense/reports/${parentId}/audits`,
@@ -323,7 +338,7 @@ export class ExpenseAPI extends ManageBaseAPI {
   getExpenseReportsByParentIdAuditsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ExpenseReportAudit> = {},
   ): Promise<ExpenseReportAudit> {
     return this.request({
       path: `/expense/reports/${parentId}/audits/${id}`,
@@ -334,7 +349,7 @@ export class ExpenseAPI extends ManageBaseAPI {
 
   getExpenseReportsByParentIdAuditsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/expense/reports/${parentId}/audits/count`,
@@ -343,7 +358,7 @@ export class ExpenseAPI extends ManageBaseAPI {
     })
   }
 
-  getExpenseReportsCount(params: CommonParameters = {}): Promise<Count> {
+  getExpenseReportsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/expense/reports/count`,
       method: 'get',
@@ -351,7 +366,7 @@ export class ExpenseAPI extends ManageBaseAPI {
     })
   }
 
-  getExpenseTypes(params: CommonParameters = {}): Promise<Array<ExpenseType>> {
+  getExpenseTypes(params: CommonParameters<ExpenseType> = {}): Promise<Array<ExpenseType>> {
     return this.request({
       path: `/expense/types`,
       method: 'get',
@@ -367,7 +382,10 @@ export class ExpenseAPI extends ManageBaseAPI {
     })
   }
 
-  getExpenseTypesById(id: number, params: CommonParameters = {}): Promise<ExpenseType> {
+  getExpenseTypesById(
+    id: number,
+    params: CommonParameters<ExpenseType> = {},
+  ): Promise<ExpenseType> {
     return this.request({
       path: `/expense/types/${id}`,
       method: 'get',
@@ -398,7 +416,10 @@ export class ExpenseAPI extends ManageBaseAPI {
     })
   }
 
-  getExpenseTypesByIdInfo(id: number, params: CommonParameters = {}): Promise<ExpenseTypeInfo> {
+  getExpenseTypesByIdInfo(
+    id: number,
+    params: CommonParameters<ExpenseTypeInfo> = {},
+  ): Promise<ExpenseTypeInfo> {
     return this.request({
       path: `/expense/types/${id}/info`,
       method: 'get',
@@ -406,7 +427,7 @@ export class ExpenseAPI extends ManageBaseAPI {
     })
   }
 
-  getExpenseTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getExpenseTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/expense/types/count`,
       method: 'get',
@@ -414,7 +435,9 @@ export class ExpenseAPI extends ManageBaseAPI {
     })
   }
 
-  getExpenseTypesInfo(params: CommonParameters = {}): Promise<Array<ExpenseTypeInfo>> {
+  getExpenseTypesInfo(
+    params: CommonParameters<ExpenseTypeInfo> = {},
+  ): Promise<Array<ExpenseTypeInfo>> {
     return this.request({
       path: `/expense/types/info`,
       method: 'get',

--- a/src/Manage/FinanceAPI.ts
+++ b/src/Manage/FinanceAPI.ts
@@ -174,7 +174,9 @@ export type WorkRoleExemption = schemas['WorkRoleExemption']
  * @public
  */
 export class FinanceAPI extends ManageBaseAPI {
-  getFinanceAccountingBatches(params: CommonParameters = {}): Promise<Array<AccountingBatch>> {
+  getFinanceAccountingBatches(
+    params: CommonParameters<AccountingBatch> = {},
+  ): Promise<Array<AccountingBatch>> {
     return this.request({
       path: `/finance/accounting/batches`,
       method: 'get',
@@ -194,7 +196,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAccountingBatchesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AccountingBatch> = {},
   ): Promise<AccountingBatch> {
     return this.request({
       path: `/finance/accounting/batches/${id}`,
@@ -223,7 +225,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAccountingBatchesByParentIdEntries(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BatchEntry> = {},
   ): Promise<Array<BatchEntry>> {
     return this.request({
       path: `/finance/accounting/batches/${parentId}/entries`,
@@ -235,7 +237,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceAccountingBatchesByParentIdEntriesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BatchEntry> = {},
   ): Promise<BatchEntry> {
     return this.request({
       path: `/finance/accounting/batches/${parentId}/entries/${id}`,
@@ -246,7 +248,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAccountingBatchesByParentIdEntriesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/accounting/batches/${parentId}/entries/count`,
@@ -255,7 +257,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceAccountingBatchesCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceAccountingBatchesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/accounting/batches/count`,
       method: 'get',
@@ -274,7 +276,7 @@ export class FinanceAPI extends ManageBaseAPI {
   }
 
   getFinanceAccountingUnpostedexpenses(
-    params: CommonParameters = {},
+    params: CommonParameters<UnpostedExpense> = {},
   ): Promise<Array<UnpostedExpense>> {
     return this.request({
       path: `/finance/accounting/unpostedexpenses`,
@@ -285,7 +287,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAccountingUnpostedexpensesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<UnpostedExpense> = {},
   ): Promise<UnpostedExpense> {
     return this.request({
       path: `/finance/accounting/unpostedexpenses/${id}`,
@@ -296,7 +298,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAccountingUnpostedexpensesByParentIdTaxableLevels(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<UnpostedExpenseTaxableLevel> = {},
   ): Promise<Array<UnpostedExpenseTaxableLevel>> {
     return this.request({
       path: `/finance/accounting/unpostedexpenses/${parentId}/taxableLevels`,
@@ -308,7 +310,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceAccountingUnpostedexpensesByParentIdTaxableLevelsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<UnpostedExpenseTaxableLevel> = {},
   ): Promise<UnpostedExpenseTaxableLevel> {
     return this.request({
       path: `/finance/accounting/unpostedexpenses/${parentId}/taxableLevels/${id}`,
@@ -319,7 +321,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAccountingUnpostedexpensesByParentIdTaxableLevelsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/accounting/unpostedexpenses/${parentId}/taxableLevels/count`,
@@ -328,7 +330,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceAccountingUnpostedexpensesCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceAccountingUnpostedexpensesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/accounting/unpostedexpenses/count`,
       method: 'get',
@@ -337,7 +339,7 @@ export class FinanceAPI extends ManageBaseAPI {
   }
 
   getFinanceAccountingUnpostedinvoices(
-    params: CommonParameters = {},
+    params: CommonParameters<UnpostedInvoice> = {},
   ): Promise<Array<UnpostedInvoice>> {
     return this.request({
       path: `/finance/accounting/unpostedinvoices`,
@@ -348,7 +350,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAccountingUnpostedinvoicesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<UnpostedInvoice> = {},
   ): Promise<UnpostedInvoice> {
     return this.request({
       path: `/finance/accounting/unpostedinvoices/${id}`,
@@ -359,7 +361,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAccountingUnpostedinvoicesByParentIdTaxableLevels(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<UnpostedInvoiceTaxableLevel> = {},
   ): Promise<Array<UnpostedInvoiceTaxableLevel>> {
     return this.request({
       path: `/finance/accounting/unpostedinvoices/${parentId}/taxableLevels`,
@@ -371,7 +373,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceAccountingUnpostedinvoicesByParentIdTaxableLevelsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<UnpostedInvoiceTaxableLevel> = {},
   ): Promise<UnpostedInvoiceTaxableLevel> {
     return this.request({
       path: `/finance/accounting/unpostedinvoices/${parentId}/taxableLevels/${id}`,
@@ -382,7 +384,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAccountingUnpostedinvoicesByParentIdTaxableLevelsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/accounting/unpostedinvoices/${parentId}/taxableLevels/count`,
@@ -391,7 +393,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceAccountingUnpostedinvoicesCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceAccountingUnpostedinvoicesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/accounting/unpostedinvoices/count`,
       method: 'get',
@@ -400,7 +402,7 @@ export class FinanceAPI extends ManageBaseAPI {
   }
 
   getFinanceAccountingUnpostedpayments(
-    params: CommonParameters = {},
+    params: CommonParameters<UnpostedPayments> = {},
   ): Promise<Array<UnpostedPayments>> {
     return this.request({
       path: `/finance/accounting/unpostedpayments`,
@@ -411,7 +413,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAccountingUnpostedPaymentsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<UnpostedPayments> = {},
   ): Promise<UnpostedPayments> {
     return this.request({
       path: `/finance/accounting/unpostedPayments/${id}`,
@@ -420,7 +422,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceAccountingUnpostedPaymentsCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceAccountingUnpostedPaymentsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/accounting/unpostedPayments/count`,
       method: 'get',
@@ -429,7 +431,7 @@ export class FinanceAPI extends ManageBaseAPI {
   }
 
   getFinanceAccountingUnpostedprocurement(
-    params: CommonParameters = {},
+    params: CommonParameters<UnpostedProcurement> = {},
   ): Promise<Array<UnpostedProcurement>> {
     return this.request({
       path: `/finance/accounting/unpostedprocurement`,
@@ -440,7 +442,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAccountingUnpostedprocurementById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<UnpostedProcurement> = {},
   ): Promise<UnpostedProcurement> {
     return this.request({
       path: `/finance/accounting/unpostedprocurement/${id}`,
@@ -451,7 +453,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAccountingUnpostedprocurementByParentIdTaxableLevels(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<UnpostedProcurementTaxableLevel> = {},
   ): Promise<Array<UnpostedProcurementTaxableLevel>> {
     return this.request({
       path: `/finance/accounting/unpostedprocurement/${parentId}/taxableLevels`,
@@ -463,7 +465,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceAccountingUnpostedprocurementByParentIdTaxableLevelsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<UnpostedProcurementTaxableLevel> = {},
   ): Promise<UnpostedProcurementTaxableLevel> {
     return this.request({
       path: `/finance/accounting/unpostedprocurement/${parentId}/taxableLevels/${id}`,
@@ -474,7 +476,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAccountingUnpostedprocurementByParentIdTaxableLevelsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/accounting/unpostedprocurement/${parentId}/taxableLevels/count`,
@@ -483,7 +485,9 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceAccountingUnpostedprocurementCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceAccountingUnpostedprocurementCount(
+    params: CommonParameters<Count> = {},
+  ): Promise<Count> {
     return this.request({
       path: `/finance/accounting/unpostedprocurement/count`,
       method: 'get',
@@ -491,7 +495,9 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceAccountingPackages(params: CommonParameters = {}): Promise<Array<AccountingPackage>> {
+  getFinanceAccountingPackages(
+    params: CommonParameters<AccountingPackage> = {},
+  ): Promise<Array<AccountingPackage>> {
     return this.request({
       path: `/finance/accountingPackages`,
       method: 'get',
@@ -501,7 +507,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAccountingPackagesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AccountingPackage> = {},
   ): Promise<AccountingPackage> {
     return this.request({
       path: `/finance/accountingPackages/${id}`,
@@ -510,7 +516,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceAccountingPackagesCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceAccountingPackagesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/accountingPackages/count`,
       method: 'get',
@@ -519,7 +525,7 @@ export class FinanceAPI extends ManageBaseAPI {
   }
 
   getFinanceAccountingPackageSetup(
-    params: CommonParameters = {},
+    params: CommonParameters<AccountingPackageSetup> = {},
   ): Promise<Array<AccountingPackageSetup>> {
     return this.request({
       path: `/finance/accountingPackageSetup`,
@@ -530,7 +536,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAccountingPackageSetupById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AccountingPackageSetup> = {},
   ): Promise<AccountingPackageSetup> {
     return this.request({
       path: `/finance/accountingPackageSetup/${id}`,
@@ -561,7 +567,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceAccountingPackageSetupCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceAccountingPackageSetupCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/accountingPackageSetup/count`,
       method: 'get',
@@ -569,7 +575,9 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceAgreementrecap(params: CommonParameters = {}): Promise<Array<AgreementRecap>> {
+  getFinanceAgreementrecap(
+    params: CommonParameters<AgreementRecap> = {},
+  ): Promise<Array<AgreementRecap>> {
     return this.request({
       path: `/finance/agreementrecap/`,
       method: 'get',
@@ -577,7 +585,10 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceAgreementrecapById(id: number, params: CommonParameters = {}): Promise<AgreementRecap> {
+  getFinanceAgreementrecapById(
+    id: number,
+    params: CommonParameters<AgreementRecap> = {},
+  ): Promise<AgreementRecap> {
     return this.request({
       path: `/finance/agreementrecap/${id}`,
       method: 'get',
@@ -585,7 +596,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceAgreements(params: CommonParameters = {}): Promise<Array<Agreement>> {
+  getFinanceAgreements(params: CommonParameters<Agreement> = {}): Promise<Array<Agreement>> {
     return this.request({
       path: `/finance/agreements`,
       method: 'get',
@@ -601,7 +612,10 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceAgreementsById(id: number, params: CommonParameters = {}): Promise<Agreement> {
+  getFinanceAgreementsById(
+    id: number,
+    params: CommonParameters<Agreement> = {},
+  ): Promise<Agreement> {
     return this.request({
       path: `/finance/agreements/${id}`,
       method: 'get',
@@ -638,7 +652,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceAgreementsByIdApplicationParametersByPodId(
     id: number,
     podId: string,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementApplicationParameters> = {},
   ): Promise<AgreementApplicationParameters> {
     return this.request({
       path: `/finance/agreements/${id}/applicationParameters/${podId}`,
@@ -656,7 +670,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementsByIdQuickAccessCount(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementTabsCount> = {},
   ): Promise<AgreementTabsCount> {
     return this.request({
       path: `/finance/agreements/${id}/quickAccess/count`,
@@ -668,7 +682,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceAgreementsByIdRecurringParametersByPodId(
     id: number,
     podId: string,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementRecurringParameters> = {},
   ): Promise<AgreementRecurringParameters> {
     return this.request({
       path: `/finance/agreements/${id}/recurringParameters/${podId}`,
@@ -679,7 +693,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementsByParentIdAdditions(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Addition> = {},
   ): Promise<Array<Addition>> {
     return this.request({
       path: `/finance/agreements/${parentId}/additions`,
@@ -702,7 +716,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceAgreementsByParentIdAdditionsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Addition> = {},
   ): Promise<Addition> {
     return this.request({
       path: `/finance/agreements/${parentId}/additions/${id}`,
@@ -747,7 +761,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementsByParentIdAdditionsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/agreements/${parentId}/additions/count`,
@@ -758,7 +772,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementsByParentIdAdjustments(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementAdjustment> = {},
   ): Promise<Array<AgreementAdjustment>> {
     return this.request({
       path: `/finance/agreements/${parentId}/adjustments`,
@@ -781,7 +795,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceAgreementsByParentIdAdjustmentsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementAdjustment> = {},
   ): Promise<AgreementAdjustment> {
     return this.request({
       path: `/finance/agreements/${parentId}/adjustments/${id}`,
@@ -826,7 +840,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementsByParentIdAdjustmentsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/agreements/${parentId}/adjustments/count`,
@@ -837,7 +851,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementsByParentIdBoardDefaults(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardDefault> = {},
   ): Promise<Array<BoardDefault>> {
     return this.request({
       path: `/finance/agreements/${parentId}/boardDefaults`,
@@ -860,7 +874,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceAgreementsByParentIdBoardDefaultsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardDefault> = {},
   ): Promise<BoardDefault> {
     return this.request({
       path: `/finance/agreements/${parentId}/boardDefaults/${id}`,
@@ -905,7 +919,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementsByParentIdBoardDefaultsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/agreements/${parentId}/boardDefaults/count`,
@@ -916,7 +930,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementsByParentIdConfigurations(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ConfigurationReference> = {},
   ): Promise<Array<ConfigurationReference>> {
     return this.request({
       path: `/finance/agreements/${parentId}/configurations`,
@@ -939,7 +953,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceAgreementsByParentIdConfigurationsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ConfigurationReference> = {},
   ): Promise<ConfigurationReference> {
     return this.request({
       path: `/finance/agreements/${parentId}/configurations/${id}`,
@@ -960,7 +974,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementsByParentIdConfigurationsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/agreements/${parentId}/configurations/count`,
@@ -978,7 +992,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementsByParentIdSites(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementSite> = {},
   ): Promise<Array<AgreementSite>> {
     return this.request({
       path: `/finance/agreements/${parentId}/sites`,
@@ -1001,7 +1015,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceAgreementsByParentIdSitesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementSite> = {},
   ): Promise<AgreementSite> {
     return this.request({
       path: `/finance/agreements/${parentId}/sites/${id}`,
@@ -1046,7 +1060,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementsByParentIdSitesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/agreements/${parentId}/sites/count`,
@@ -1057,7 +1071,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementsByParentIdWorkRoleExclusions(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementWorkRoleExclusion> = {},
   ): Promise<Array<AgreementWorkRoleExclusion>> {
     return this.request({
       path: `/finance/agreements/${parentId}/workRoleExclusions`,
@@ -1089,7 +1103,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementsByParentIdWorkRoleExclusionsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/agreements/${parentId}/workRoleExclusions/count`,
@@ -1100,7 +1114,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementsByParentIdWorkroles(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementWorkRole> = {},
   ): Promise<Array<AgreementWorkRole>> {
     return this.request({
       path: `/finance/agreements/${parentId}/workroles`,
@@ -1123,7 +1137,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceAgreementsByParentIdWorkrolesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementWorkRole> = {},
   ): Promise<AgreementWorkRole> {
     return this.request({
       path: `/finance/agreements/${parentId}/workroles/${id}`,
@@ -1168,7 +1182,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementsByParentIdWorkrolesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/agreements/${parentId}/workroles/count`,
@@ -1179,7 +1193,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementsByParentIdWorkTypeExclusions(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementWorkTypeExclusion> = {},
   ): Promise<Array<AgreementWorkTypeExclusion>> {
     return this.request({
       path: `/finance/agreements/${parentId}/workTypeExclusions`,
@@ -1211,7 +1225,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementsByParentIdWorkTypeExclusionsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/agreements/${parentId}/workTypeExclusions/count`,
@@ -1222,7 +1236,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementsByParentIdWorktypes(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementWorkType> = {},
   ): Promise<Array<AgreementWorkType>> {
     return this.request({
       path: `/finance/agreements/${parentId}/worktypes`,
@@ -1245,7 +1259,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceAgreementsByParentIdWorktypesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementWorkType> = {},
   ): Promise<AgreementWorkType> {
     return this.request({
       path: `/finance/agreements/${parentId}/worktypes/${id}`,
@@ -1290,7 +1304,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementsByParentIdWorktypesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/agreements/${parentId}/worktypes/count`,
@@ -1299,7 +1313,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceAgreementsCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceAgreementsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/agreements/count`,
       method: 'get',
@@ -1307,7 +1321,9 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceAgreementsTypes(params: CommonParameters = {}): Promise<Array<AgreementType>> {
+  getFinanceAgreementsTypes(
+    params: CommonParameters<AgreementType> = {},
+  ): Promise<Array<AgreementType>> {
     return this.request({
       path: `/finance/agreements/types`,
       method: 'get',
@@ -1323,7 +1339,10 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceAgreementsTypesById(id: number, params: CommonParameters = {}): Promise<AgreementType> {
+  getFinanceAgreementsTypesById(
+    id: number,
+    params: CommonParameters<AgreementType> = {},
+  ): Promise<AgreementType> {
     return this.request({
       path: `/finance/agreements/types/${id}`,
       method: 'get',
@@ -1359,7 +1378,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementsTypesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementTypeInfo> = {},
   ): Promise<AgreementTypeInfo> {
     return this.request({
       path: `/finance/agreements/types/${id}/info`,
@@ -1370,7 +1389,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementsTypesByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/finance/agreements/types/${id}/usages`,
@@ -1381,7 +1400,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementsTypesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/finance/agreements/types/${id}/usages/list`,
@@ -1390,7 +1409,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceAgreementsTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceAgreementsTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/agreements/types/count`,
       method: 'get',
@@ -1398,7 +1417,9 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceAgreementsTypesInfo(params: CommonParameters = {}): Promise<Array<AgreementTypeInfo>> {
+  getFinanceAgreementsTypesInfo(
+    params: CommonParameters<AgreementTypeInfo> = {},
+  ): Promise<Array<AgreementTypeInfo>> {
     return this.request({
       path: `/finance/agreements/types/info`,
       method: 'get',
@@ -1406,7 +1427,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceAgreementsTypesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceAgreementsTypesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/agreements/types/info/count`,
       method: 'get',
@@ -1423,7 +1444,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementTypesByParentIdBoardDefaults(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementTypeBoardDefault> = {},
   ): Promise<Array<AgreementTypeBoardDefault>> {
     return this.request({
       path: `/finance/agreementTypes/${parentId}/boardDefaults`,
@@ -1446,7 +1467,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceAgreementTypesByParentIdBoardDefaultsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementTypeBoardDefault> = {},
   ): Promise<AgreementTypeBoardDefault> {
     return this.request({
       path: `/finance/agreementTypes/${parentId}/boardDefaults/${id}`,
@@ -1491,7 +1512,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementTypesByParentIdBoardDefaultsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/agreementTypes/${parentId}/boardDefaults/count`,
@@ -1502,7 +1523,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementTypesByParentIdWorkRoleExclusions(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementTypeWorkRoleExclusion> = {},
   ): Promise<Array<AgreementTypeWorkRoleExclusion>> {
     return this.request({
       path: `/finance/agreementTypes/${parentId}/workRoleExclusions`,
@@ -1525,7 +1546,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceAgreementTypesByParentIdWorkRoleExclusionsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementTypeWorkRoleExclusion> = {},
   ): Promise<AgreementTypeWorkRoleExclusion> {
     return this.request({
       path: `/finance/agreementTypes/${parentId}/workRoleExclusions/${id}`,
@@ -1546,7 +1567,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementTypesByParentIdWorkRoleExclusionsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/agreementTypes/${parentId}/workRoleExclusions/count`,
@@ -1557,7 +1578,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementTypesByParentIdWorkroles(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementTypeWorkRole> = {},
   ): Promise<Array<AgreementTypeWorkRole>> {
     return this.request({
       path: `/finance/agreementTypes/${parentId}/workroles`,
@@ -1580,7 +1601,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceAgreementTypesByParentIdWorkrolesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementTypeWorkRole> = {},
   ): Promise<AgreementTypeWorkRole> {
     return this.request({
       path: `/finance/agreementTypes/${parentId}/workroles/${id}`,
@@ -1625,7 +1646,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementTypesByParentIdWorkrolesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/agreementTypes/${parentId}/workroles/count`,
@@ -1636,7 +1657,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementTypesByParentIdWorkrolesInfo(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementTypeWorkRoleInfo> = {},
   ): Promise<Array<AgreementTypeWorkRoleInfo>> {
     return this.request({
       path: `/finance/agreementTypes/${parentId}/workroles/info`,
@@ -1648,7 +1669,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceAgreementTypesByParentIdWorkrolesInfoById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementTypeWorkRoleInfo> = {},
   ): Promise<AgreementTypeWorkRoleInfo> {
     return this.request({
       path: `/finance/agreementTypes/${parentId}/workroles/info/${id}`,
@@ -1659,7 +1680,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementTypesByParentIdWorkrolesInfoCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/agreementTypes/${parentId}/workroles/info/count`,
@@ -1670,7 +1691,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementTypesByParentIdWorkTypeExclusions(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementTypeWorkTypeExclusion> = {},
   ): Promise<Array<AgreementTypeWorkTypeExclusion>> {
     return this.request({
       path: `/finance/agreementTypes/${parentId}/workTypeExclusions`,
@@ -1693,7 +1714,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceAgreementTypesByParentIdWorkTypeExclusionsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementTypeWorkTypeExclusion> = {},
   ): Promise<AgreementTypeWorkTypeExclusion> {
     return this.request({
       path: `/finance/agreementTypes/${parentId}/workTypeExclusions/${id}`,
@@ -1714,7 +1735,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementTypesByParentIdWorkTypeExclusionsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/agreementTypes/${parentId}/workTypeExclusions/count`,
@@ -1725,7 +1746,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementTypesByParentIdWorktypes(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementTypeWorkType> = {},
   ): Promise<Array<AgreementTypeWorkType>> {
     return this.request({
       path: `/finance/agreementTypes/${parentId}/worktypes`,
@@ -1748,7 +1769,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceAgreementTypesByParentIdWorktypesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementTypeWorkType> = {},
   ): Promise<AgreementTypeWorkType> {
     return this.request({
       path: `/finance/agreementTypes/${parentId}/worktypes/${id}`,
@@ -1793,7 +1814,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceAgreementTypesByParentIdWorktypesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/agreementTypes/${parentId}/worktypes/count`,
@@ -1802,7 +1823,9 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceBatchSetups(params: CommonParameters = {}): Promise<Array<AgreementBatchSetup>> {
+  getFinanceBatchSetups(
+    params: CommonParameters<AgreementBatchSetup> = {},
+  ): Promise<Array<AgreementBatchSetup>> {
     return this.request({
       path: `/finance/batchSetups`,
       method: 'get',
@@ -1812,7 +1835,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceBatchSetupsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AgreementBatchSetup> = {},
   ): Promise<AgreementBatchSetup> {
     return this.request({
       path: `/finance/batchSetups/${id}`,
@@ -1843,7 +1866,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceBatchSetupsCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceBatchSetupsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/batchSetups/count`,
       method: 'get',
@@ -1851,7 +1874,9 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceBillingCycles(params: CommonParameters = {}): Promise<Array<BillingCycle>> {
+  getFinanceBillingCycles(
+    params: CommonParameters<BillingCycle> = {},
+  ): Promise<Array<BillingCycle>> {
     return this.request({
       path: `/finance/billingCycles`,
       method: 'get',
@@ -1867,7 +1892,10 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceBillingCyclesById(id: number, params: CommonParameters = {}): Promise<BillingCycle> {
+  getFinanceBillingCyclesById(
+    id: number,
+    params: CommonParameters<BillingCycle> = {},
+  ): Promise<BillingCycle> {
     return this.request({
       path: `/finance/billingCycles/${id}`,
       method: 'get',
@@ -1903,7 +1931,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceBillingCyclesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BillingCycleInfo> = {},
   ): Promise<BillingCycleInfo> {
     return this.request({
       path: `/finance/billingCycles/${id}/info`,
@@ -1914,7 +1942,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceBillingCyclesByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/finance/billingCycles/${id}/usages`,
@@ -1925,7 +1953,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceBillingCyclesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/finance/billingCycles/${id}/usages/list`,
@@ -1934,7 +1962,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceBillingCyclesCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceBillingCyclesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/billingCycles/count`,
       method: 'get',
@@ -1942,7 +1970,9 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceBillingCyclesInfo(params: CommonParameters = {}): Promise<Array<BillingCycleInfo>> {
+  getFinanceBillingCyclesInfo(
+    params: CommonParameters<BillingCycleInfo> = {},
+  ): Promise<Array<BillingCycleInfo>> {
     return this.request({
       path: `/finance/billingCycles/info`,
       method: 'get',
@@ -1950,7 +1980,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceBillingCyclesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceBillingCyclesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/billingCycles/info/count`,
       method: 'get',
@@ -1958,7 +1988,9 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceBillingSetups(params: CommonParameters = {}): Promise<Array<BillingSetup>> {
+  getFinanceBillingSetups(
+    params: CommonParameters<BillingSetup> = {},
+  ): Promise<Array<BillingSetup>> {
     return this.request({
       path: `/finance/billingSetups`,
       method: 'get',
@@ -1974,7 +2006,10 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceBillingSetupsById(id: number, params: CommonParameters = {}): Promise<BillingSetup> {
+  getFinanceBillingSetupsById(
+    id: number,
+    params: CommonParameters<BillingSetup> = {},
+  ): Promise<BillingSetup> {
     return this.request({
       path: `/finance/billingSetups/${id}`,
       method: 'get',
@@ -2010,7 +2045,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceBillingSetupsByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BillingSetupInfo> = {},
   ): Promise<BillingSetupInfo> {
     return this.request({
       path: `/finance/billingSetups/${id}/info`,
@@ -2021,7 +2056,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceBillingSetupsByParentIdRoutings(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BillingSetupRouting> = {},
   ): Promise<Array<BillingSetupRouting>> {
     return this.request({
       path: `/finance/billingSetups/${parentId}/routings`,
@@ -2044,7 +2079,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceBillingSetupsByParentIdRoutingsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BillingSetupRouting> = {},
   ): Promise<BillingSetupRouting> {
     return this.request({
       path: `/finance/billingSetups/${parentId}/routings/${id}`,
@@ -2089,7 +2124,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceBillingSetupsByParentIdRoutingsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/billingSetups/${parentId}/routings/count`,
@@ -2098,7 +2133,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceBillingSetupsCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceBillingSetupsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/billingSetups/count`,
       method: 'get',
@@ -2106,7 +2141,9 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceBillingSetupsInfo(params: CommonParameters = {}): Promise<Array<BillingSetupInfo>> {
+  getFinanceBillingSetupsInfo(
+    params: CommonParameters<BillingSetupInfo> = {},
+  ): Promise<Array<BillingSetupInfo>> {
     return this.request({
       path: `/finance/billingSetups/info`,
       method: 'get',
@@ -2114,7 +2151,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceBillingSetupsInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceBillingSetupsInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/billingSetups/info/count`,
       method: 'get',
@@ -2122,7 +2159,9 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceBillingStatuses(params: CommonParameters = {}): Promise<Array<BillingStatus>> {
+  getFinanceBillingStatuses(
+    params: CommonParameters<BillingStatus> = {},
+  ): Promise<Array<BillingStatus>> {
     return this.request({
       path: `/finance/billingStatuses`,
       method: 'get',
@@ -2138,7 +2177,10 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceBillingStatusesById(id: number, params: CommonParameters = {}): Promise<BillingStatus> {
+  getFinanceBillingStatusesById(
+    id: number,
+    params: CommonParameters<BillingStatus> = {},
+  ): Promise<BillingStatus> {
     return this.request({
       path: `/finance/billingStatuses/${id}`,
       method: 'get',
@@ -2174,7 +2216,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceBillingStatusesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BillingStatusInfo> = {},
   ): Promise<BillingStatusInfo> {
     return this.request({
       path: `/finance/billingStatuses/${id}/info`,
@@ -2185,7 +2227,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceBillingStatusesByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/finance/billingStatuses/${id}/usages`,
@@ -2196,7 +2238,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceBillingStatusesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/finance/billingStatuses/${id}/usages/list`,
@@ -2205,7 +2247,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceBillingStatusesCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceBillingStatusesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/billingStatuses/count`,
       method: 'get',
@@ -2213,7 +2255,9 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceBillingStatusesInfo(params: CommonParameters = {}): Promise<Array<BillingStatusInfo>> {
+  getFinanceBillingStatusesInfo(
+    params: CommonParameters<BillingStatusInfo> = {},
+  ): Promise<Array<BillingStatusInfo>> {
     return this.request({
       path: `/finance/billingStatuses/info`,
       method: 'get',
@@ -2221,7 +2265,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceBillingStatusesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceBillingStatusesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/billingStatuses/info/count`,
       method: 'get',
@@ -2229,7 +2273,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceBillingTerms(params: CommonParameters = {}): Promise<Array<BillingTerm>> {
+  getFinanceBillingTerms(params: CommonParameters<BillingTerm> = {}): Promise<Array<BillingTerm>> {
     return this.request({
       path: `/finance/billingTerms`,
       method: 'get',
@@ -2245,7 +2289,10 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceBillingTermsById(id: number, params: CommonParameters = {}): Promise<BillingTerm> {
+  getFinanceBillingTermsById(
+    id: number,
+    params: CommonParameters<BillingTerm> = {},
+  ): Promise<BillingTerm> {
     return this.request({
       path: `/finance/billingTerms/${id}`,
       method: 'get',
@@ -2281,7 +2328,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceBillingTermsByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BillingTermInfo> = {},
   ): Promise<BillingTermInfo> {
     return this.request({
       path: `/finance/billingTerms/${id}/info`,
@@ -2292,7 +2339,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceBillingTermsByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/finance/billingTerms/${id}/usages`,
@@ -2303,7 +2350,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceBillingTermsByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/finance/billingTerms/${id}/usages/list`,
@@ -2312,7 +2359,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceBillingTermsCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceBillingTermsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/billingTerms/count`,
       method: 'get',
@@ -2320,7 +2367,9 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceBillingTermsInfo(params: CommonParameters = {}): Promise<Array<BillingTermInfo>> {
+  getFinanceBillingTermsInfo(
+    params: CommonParameters<BillingTermInfo> = {},
+  ): Promise<Array<BillingTermInfo>> {
     return this.request({
       path: `/finance/billingTerms/info`,
       method: 'get',
@@ -2328,7 +2377,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceBillingTermsInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceBillingTermsInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/billingTerms/info/count`,
       method: 'get',
@@ -2355,7 +2404,9 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceCompanyFinance(params: CommonParameters = {}): Promise<Array<CompanyFinance>> {
+  getFinanceCompanyFinance(
+    params: CommonParameters<CompanyFinance> = {},
+  ): Promise<Array<CompanyFinance>> {
     return this.request({
       path: `/finance/companyFinance/`,
       method: 'get',
@@ -2363,7 +2414,10 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceCompanyFinanceById(id: number, params: CommonParameters = {}): Promise<CompanyFinance> {
+  getFinanceCompanyFinanceById(
+    id: number,
+    params: CommonParameters<CompanyFinance> = {},
+  ): Promise<CompanyFinance> {
     return this.request({
       path: `/finance/companyFinance/${id}`,
       method: 'get',
@@ -2393,7 +2447,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceCompanyFinanceCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceCompanyFinanceCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/companyFinance/count`,
       method: 'get',
@@ -2401,7 +2455,9 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceCurrencies(params: CommonParameters = {}): Promise<Array<FinanceCurrency>> {
+  getFinanceCurrencies(
+    params: CommonParameters<FinanceCurrency> = {},
+  ): Promise<Array<FinanceCurrency>> {
     return this.request({
       path: `/finance/currencies`,
       method: 'get',
@@ -2417,7 +2473,10 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceCurrenciesById(id: number, params: CommonParameters = {}): Promise<FinanceCurrency> {
+  getFinanceCurrenciesById(
+    id: number,
+    params: CommonParameters<FinanceCurrency> = {},
+  ): Promise<FinanceCurrency> {
     return this.request({
       path: `/finance/currencies/${id}`,
       method: 'get',
@@ -2451,7 +2510,10 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceCurrenciesByIdInfo(id: number, params: CommonParameters = {}): Promise<CurrencyInfo> {
+  getFinanceCurrenciesByIdInfo(
+    id: number,
+    params: CommonParameters<CurrencyInfo> = {},
+  ): Promise<CurrencyInfo> {
     return this.request({
       path: `/finance/currencies/${id}/info`,
       method: 'get',
@@ -2459,7 +2521,10 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceCurrenciesByIdUsages(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getFinanceCurrenciesByIdUsages(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/finance/currencies/${id}/usages`,
       method: 'get',
@@ -2469,7 +2534,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceCurrenciesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/finance/currencies/${id}/usages/list`,
@@ -2478,7 +2543,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceCurrenciesCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceCurrenciesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/currencies/count`,
       method: 'get',
@@ -2486,7 +2551,9 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceCurrenciesInfo(params: CommonParameters = {}): Promise<Array<CurrencyInfo>> {
+  getFinanceCurrenciesInfo(
+    params: CommonParameters<CurrencyInfo> = {},
+  ): Promise<Array<CurrencyInfo>> {
     return this.request({
       path: `/finance/currencies/info`,
       method: 'get',
@@ -2494,7 +2561,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceCurrenciesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceCurrenciesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/currencies/info/count`,
       method: 'get',
@@ -2502,7 +2569,9 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceDeliveryMethods(params: CommonParameters = {}): Promise<Array<DeliveryMethod>> {
+  getFinanceDeliveryMethods(
+    params: CommonParameters<DeliveryMethod> = {},
+  ): Promise<Array<DeliveryMethod>> {
     return this.request({
       path: `/finance/deliveryMethods`,
       method: 'get',
@@ -2520,7 +2589,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceDeliveryMethodsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<DeliveryMethod> = {},
   ): Promise<DeliveryMethod> {
     return this.request({
       path: `/finance/deliveryMethods/${id}`,
@@ -2558,7 +2627,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceDeliveryMethodsCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceDeliveryMethodsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/deliveryMethods/count`,
       method: 'get',
@@ -2566,7 +2635,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceGlAccounts(params: CommonParameters = {}): Promise<Array<GLAccount>> {
+  getFinanceGlAccounts(params: CommonParameters<GLAccount> = {}): Promise<Array<GLAccount>> {
     return this.request({
       path: `/finance/glAccounts`,
       method: 'get',
@@ -2582,7 +2651,10 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceGlAccountsById(id: number, params: CommonParameters = {}): Promise<GLAccount> {
+  getFinanceGlAccountsById(
+    id: number,
+    params: CommonParameters<GLAccount> = {},
+  ): Promise<GLAccount> {
     return this.request({
       path: `/finance/glAccounts/${id}`,
       method: 'get',
@@ -2616,7 +2688,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceGlAccountsCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceGlAccountsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/glAccounts/count`,
       method: 'get',
@@ -2624,7 +2696,9 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceGlAccountsMappedTypes(params: CommonParameters = {}): Promise<Array<MappedType>> {
+  getFinanceGlAccountsMappedTypes(
+    params: CommonParameters<MappedType> = {},
+  ): Promise<Array<MappedType>> {
     return this.request({
       path: `/finance/glAccounts/mappedTypes`,
       method: 'get',
@@ -2632,7 +2706,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceGlAccountsMappedTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceGlAccountsMappedTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/glAccounts/mappedTypes/count`,
       method: 'get',
@@ -2640,7 +2714,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceGlCaptions(params: CommonParameters = {}): Promise<Array<GLCaption>> {
+  getFinanceGlCaptions(params: CommonParameters<GLCaption> = {}): Promise<Array<GLCaption>> {
     return this.request({
       path: `/finance/glCaptions`,
       method: 'get',
@@ -2648,7 +2722,10 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceGlCaptionsById(id: number, params: CommonParameters = {}): Promise<GLCaption> {
+  getFinanceGlCaptionsById(
+    id: number,
+    params: CommonParameters<GLCaption> = {},
+  ): Promise<GLCaption> {
     return this.request({
       path: `/finance/glCaptions/${id}`,
       method: 'get',
@@ -2675,7 +2752,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceGlCaptionsCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceGlCaptionsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/glCaptions/count`,
       method: 'get',
@@ -2683,7 +2760,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceGlpaths(params: CommonParameters = {}): Promise<Array<GLPath>> {
+  getFinanceGlpaths(params: CommonParameters<GLPath> = {}): Promise<Array<GLPath>> {
     return this.request({
       path: `/finance/glpaths`,
       method: 'get',
@@ -2699,7 +2776,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceGlpathsById(id: number, params: CommonParameters = {}): Promise<GLPath> {
+  getFinanceGlpathsById(id: number, params: CommonParameters<GLPath> = {}): Promise<GLPath> {
     return this.request({
       path: `/finance/glpaths/${id}`,
       method: 'get',
@@ -2730,7 +2807,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceGlpathsCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceGlpathsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/glpaths/count`,
       method: 'get',
@@ -2738,7 +2815,9 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceInfoCurrencyCodes(params: CommonParameters = {}): Promise<Array<CurrencyCode>> {
+  getFinanceInfoCurrencyCodes(
+    params: CommonParameters<CurrencyCode> = {},
+  ): Promise<Array<CurrencyCode>> {
     return this.request({
       path: `/finance/info/currencyCodes`,
       method: 'get',
@@ -2748,7 +2827,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceInfoCurrencyCodesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CurrencyCode> = {},
   ): Promise<CurrencyCode> {
     return this.request({
       path: `/finance/info/currencyCodes/${id}`,
@@ -2757,7 +2836,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceInfoCurrencyCodesCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceInfoCurrencyCodesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/info/currencyCodes/count`,
       method: 'get',
@@ -2765,7 +2844,10 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceInfoInvoiceById(id: number, params: CommonParameters = {}): Promise<InvoiceInfo> {
+  getFinanceInfoInvoiceById(
+    id: number,
+    params: CommonParameters<InvoiceInfo> = {},
+  ): Promise<InvoiceInfo> {
     return this.request({
       path: `/finance/info/invoice/${id}`,
       method: 'get',
@@ -2773,7 +2855,9 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceInfoTaxIntegrations(params: CommonParameters = {}): Promise<Array<TaxIntegrationInfo>> {
+  getFinanceInfoTaxIntegrations(
+    params: CommonParameters<TaxIntegrationInfo> = {},
+  ): Promise<Array<TaxIntegrationInfo>> {
     return this.request({
       path: `/finance/info/taxIntegrations`,
       method: 'get',
@@ -2783,7 +2867,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceInfoTaxIntegrationsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TaxIntegrationInfo> = {},
   ): Promise<TaxIntegrationInfo> {
     return this.request({
       path: `/finance/info/taxIntegrations/${id}`,
@@ -2792,7 +2876,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceInfoTaxIntegrationsCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceInfoTaxIntegrationsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/info/taxIntegrations/count`,
       method: 'get',
@@ -2801,7 +2885,7 @@ export class FinanceAPI extends ManageBaseAPI {
   }
 
   getFinanceInvoiceEmailTemplates(
-    params: CommonParameters = {},
+    params: CommonParameters<InvoiceEmailTemplate> = {},
   ): Promise<Array<InvoiceEmailTemplate>> {
     return this.request({
       path: `/finance/invoiceEmailTemplates`,
@@ -2822,7 +2906,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceInvoiceEmailTemplatesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<InvoiceEmailTemplate> = {},
   ): Promise<InvoiceEmailTemplate> {
     return this.request({
       path: `/finance/invoiceEmailTemplates/${id}`,
@@ -2862,7 +2946,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceInvoiceEmailTemplatesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<InvoiceEmailTemplateInfo> = {},
   ): Promise<InvoiceEmailTemplateInfo> {
     return this.request({
       path: `/finance/invoiceEmailTemplates/${id}/info`,
@@ -2873,7 +2957,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceInvoiceEmailTemplatesByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/finance/invoiceEmailTemplates/${id}/usages`,
@@ -2884,7 +2968,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceInvoiceEmailTemplatesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/finance/invoiceEmailTemplates/${id}/usages/list`,
@@ -2893,7 +2977,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceInvoiceEmailTemplatesCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceInvoiceEmailTemplatesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/invoiceEmailTemplates/count`,
       method: 'get',
@@ -2902,7 +2986,7 @@ export class FinanceAPI extends ManageBaseAPI {
   }
 
   getFinanceInvoiceEmailTemplatesInfo(
-    params: CommonParameters = {},
+    params: CommonParameters<InvoiceEmailTemplateInfo> = {},
   ): Promise<Array<InvoiceEmailTemplateInfo>> {
     return this.request({
       path: `/finance/invoiceEmailTemplates/info`,
@@ -2911,7 +2995,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceInvoiceEmailTemplatesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceInvoiceEmailTemplatesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/invoiceEmailTemplates/info/count`,
       method: 'get',
@@ -2919,7 +3003,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceInvoices(params: CommonParameters = {}): Promise<Array<Invoice>> {
+  getFinanceInvoices(params: CommonParameters<Invoice> = {}): Promise<Array<Invoice>> {
     return this.request({
       path: `/finance/invoices`,
       method: 'get',
@@ -2935,7 +3019,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceInvoicesById(id: number, params: CommonParameters = {}): Promise<Invoice> {
+  getFinanceInvoicesById(id: number, params: CommonParameters<Invoice> = {}): Promise<Invoice> {
     return this.request({
       path: `/finance/invoices/${id}`,
       method: 'get',
@@ -2966,18 +3050,18 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceInvoicesByIdPdf(id: number, params: CommonParameters = {}): Promise<string> {
+  getFinanceInvoicesByIdPdf(id: number, params: CommonParameters<string> = {}): Promise<string> {
     return this.request({
       path: `/finance/invoices/${id}/pdf`,
       method: 'get',
-      params,
       responseType: 'arraybuffer',
+      params,
     })
   }
 
   getFinanceInvoicesByParentIdCommissions(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<InvoiceCommission> = {},
   ): Promise<Array<InvoiceCommission>> {
     return this.request({
       path: `/finance/invoices/${parentId}/commissions`,
@@ -2989,7 +3073,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceInvoicesByParentIdCommissionsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<InvoiceCommission> = {},
   ): Promise<InvoiceCommission> {
     return this.request({
       path: `/finance/invoices/${parentId}/commissions/${id}`,
@@ -3019,7 +3103,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceInvoicesByParentIdGlEntries(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<GLEntry> = {},
   ): Promise<Array<GLEntry>> {
     return this.request({
       path: `/finance/invoices/${parentId}/glEntries/`,
@@ -3031,7 +3115,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceInvoicesByParentIdGlEntriesById(
     parentId: number,
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<GLEntry> = {},
   ): Promise<GLEntry> {
     return this.request({
       path: `/finance/invoices/${parentId}/glEntries/${id}`,
@@ -3066,7 +3150,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceInvoicesByParentIdPayments(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<InvoicePayment> = {},
   ): Promise<Array<InvoicePayment>> {
     return this.request({
       path: `/finance/invoices/${parentId}/payments`,
@@ -3089,7 +3173,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceInvoicesByParentIdPaymentsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<InvoicePayment> = {},
   ): Promise<InvoicePayment> {
     return this.request({
       path: `/finance/invoices/${parentId}/payments/${id}`,
@@ -3134,7 +3218,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceInvoicesByParentIdRoutings(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<InvoiceRouting> = {},
   ): Promise<Array<InvoiceRouting>> {
     return this.request({
       path: `/finance/invoices/${parentId}/routings`,
@@ -3157,7 +3241,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceInvoicesByParentIdRoutingsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<InvoiceRouting> = {},
   ): Promise<InvoiceRouting> {
     return this.request({
       path: `/finance/invoices/${parentId}/routings/${id}`,
@@ -3202,7 +3286,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceInvoicesByParentIdRoutingsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/invoices/${parentId}/routings/count`,
@@ -3211,7 +3295,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceInvoicesCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceInvoicesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/invoices/count`,
       method: 'get',
@@ -3219,7 +3303,9 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceInvoiceTemplates(params: CommonParameters = {}): Promise<Array<InvoiceTemplate>> {
+  getFinanceInvoiceTemplates(
+    params: CommonParameters<InvoiceTemplate> = {},
+  ): Promise<Array<InvoiceTemplate>> {
     return this.request({
       path: `/finance/invoiceTemplates`,
       method: 'get',
@@ -3237,7 +3323,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceInvoiceTemplatesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<InvoiceTemplate> = {},
   ): Promise<InvoiceTemplate> {
     return this.request({
       path: `/finance/invoiceTemplates/${id}`,
@@ -3277,7 +3363,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceInvoiceTemplatesByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/finance/invoiceTemplates/${id}/usages`,
@@ -3288,7 +3374,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceInvoiceTemplatesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/finance/invoiceTemplates/${id}/usages/list`,
@@ -3297,7 +3383,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceInvoiceTemplatesCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceInvoiceTemplatesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/invoiceTemplates/count`,
       method: 'get',
@@ -3306,7 +3392,7 @@ export class FinanceAPI extends ManageBaseAPI {
   }
 
   getFinanceInvoiceTemplateSetups(
-    params: CommonParameters = {},
+    params: CommonParameters<InvoiceTemplateSetup> = {},
   ): Promise<Array<InvoiceTemplateSetup>> {
     return this.request({
       path: `/finance/invoiceTemplateSetups`,
@@ -3317,7 +3403,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceInvoiceTemplateSetupsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<InvoiceTemplateSetup> = {},
   ): Promise<InvoiceTemplateSetup> {
     return this.request({
       path: `/finance/invoiceTemplateSetups/${id}`,
@@ -3326,7 +3412,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceInvoiceTemplateSetupsCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceInvoiceTemplateSetupsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/invoiceTemplateSetups/count`,
       method: 'get',
@@ -3334,7 +3420,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceTaxCodes(params: CommonParameters = {}): Promise<Array<TaxCode>> {
+  getFinanceTaxCodes(params: CommonParameters<TaxCode> = {}): Promise<Array<TaxCode>> {
     return this.request({
       path: `/finance/taxCodes`,
       method: 'get',
@@ -3353,7 +3439,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceTaxCodesByGrandparentIdExpenseTypeExemptionsByParentIdTaxableExpenseTypeLevels(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TaxableExpenseTypeLevel> = {},
   ): Promise<Array<TaxableExpenseTypeLevel>> {
     return this.request({
       path: `/finance/taxCodes/${grandparentId}/expenseTypeExemptions/${parentId}/taxableExpenseTypeLevels`,
@@ -3378,7 +3464,7 @@ export class FinanceAPI extends ManageBaseAPI {
     id: number,
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TaxableExpenseTypeLevel> = {},
   ): Promise<TaxableExpenseTypeLevel> {
     return this.request({
       path: `/finance/taxCodes/${grandparentId}/expenseTypeExemptions/${parentId}/taxableExpenseTypeLevels/${id}`,
@@ -3427,7 +3513,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceTaxCodesByGrandparentIdExpenseTypeExemptionsByParentIdTaxableExpenseTypeLevelsCount(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/taxCodes/${grandparentId}/expenseTypeExemptions/${parentId}/taxableExpenseTypeLevels/count`,
@@ -3439,7 +3525,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceTaxCodesByGrandparentIdProductTypeExemptionsByParentIdTaxableProductTypeLevels(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TaxableProductTypeLevel> = {},
   ): Promise<Array<TaxableProductTypeLevel>> {
     return this.request({
       path: `/finance/taxCodes/${grandparentId}/productTypeExemptions/${parentId}/taxableProductTypeLevels`,
@@ -3464,7 +3550,7 @@ export class FinanceAPI extends ManageBaseAPI {
     id: number,
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TaxableProductTypeLevel> = {},
   ): Promise<TaxableProductTypeLevel> {
     return this.request({
       path: `/finance/taxCodes/${grandparentId}/productTypeExemptions/${parentId}/taxableProductTypeLevels/${id}`,
@@ -3513,7 +3599,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceTaxCodesByGrandparentIdProductTypeExemptionsByParentIdTaxableProductTypeLevelsCount(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/taxCodes/${grandparentId}/productTypeExemptions/${parentId}/taxableProductTypeLevels/count`,
@@ -3525,7 +3611,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceTaxCodesByGrandparentIdTaxCodeXRefsByParentIdTaxableXRefLevels(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TaxableXRefLevel> = {},
   ): Promise<Array<TaxableXRefLevel>> {
     return this.request({
       path: `/finance/taxCodes/${grandparentId}/taxCodeXRefs/${parentId}/taxableXRefLevels`,
@@ -3550,7 +3636,7 @@ export class FinanceAPI extends ManageBaseAPI {
     id: number,
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TaxableXRefLevel> = {},
   ): Promise<TaxableXRefLevel> {
     return this.request({
       path: `/finance/taxCodes/${grandparentId}/taxCodeXRefs/${parentId}/taxableXRefLevels/${id}`,
@@ -3599,7 +3685,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceTaxCodesByGrandparentIdTaxCodeXRefsByParentIdTaxableXRefLevelsCount(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/taxCodes/${grandparentId}/taxCodeXRefs/${parentId}/taxableXRefLevels/count`,
@@ -3611,7 +3697,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceTaxCodesByGrandparentIdWorkRoleExemptionsByParentIdTaxableWorkRoleLevels(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TaxableWorkRoleLevel> = {},
   ): Promise<Array<TaxableWorkRoleLevel>> {
     return this.request({
       path: `/finance/taxCodes/${grandparentId}/workRoleExemptions/${parentId}/taxableWorkRoleLevels`,
@@ -3636,7 +3722,7 @@ export class FinanceAPI extends ManageBaseAPI {
     id: number,
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TaxableWorkRoleLevel> = {},
   ): Promise<TaxableWorkRoleLevel> {
     return this.request({
       path: `/finance/taxCodes/${grandparentId}/workRoleExemptions/${parentId}/taxableWorkRoleLevels/${id}`,
@@ -3685,7 +3771,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceTaxCodesByGrandparentIdWorkRoleExemptionsByParentIdTaxableWorkRoleLevelsCount(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/taxCodes/${grandparentId}/workRoleExemptions/${parentId}/taxableWorkRoleLevels/count`,
@@ -3694,7 +3780,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceTaxCodesById(id: number, params: CommonParameters = {}): Promise<TaxCode> {
+  getFinanceTaxCodesById(id: number, params: CommonParameters<TaxCode> = {}): Promise<TaxCode> {
     return this.request({
       path: `/finance/taxCodes/${id}`,
       method: 'get',
@@ -3732,7 +3818,10 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceTaxCodesByIdInfo(id: number, params: CommonParameters = {}): Promise<TaxCodeInfo> {
+  getFinanceTaxCodesByIdInfo(
+    id: number,
+    params: CommonParameters<TaxCodeInfo> = {},
+  ): Promise<TaxCodeInfo> {
     return this.request({
       path: `/finance/taxCodes/${id}/info`,
       method: 'get',
@@ -3740,7 +3829,10 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceTaxCodesByIdUsages(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getFinanceTaxCodesByIdUsages(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/finance/taxCodes/${id}/usages`,
       method: 'get',
@@ -3750,7 +3842,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceTaxCodesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/finance/taxCodes/${id}/usages/list`,
@@ -3761,7 +3853,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceTaxCodesByParentIdExpenseTypeExemptions(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ExpenseTypeExemption> = {},
   ): Promise<Array<ExpenseTypeExemption>> {
     return this.request({
       path: `/finance/taxCodes/${parentId}/expenseTypeExemptions`,
@@ -3784,7 +3876,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceTaxCodesByParentIdExpenseTypeExemptionsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ExpenseTypeExemption> = {},
   ): Promise<ExpenseTypeExemption> {
     return this.request({
       path: `/finance/taxCodes/${parentId}/expenseTypeExemptions/${id}`,
@@ -3829,7 +3921,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceTaxCodesByParentIdExpenseTypeExemptionsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/taxCodes/${parentId}/expenseTypeExemptions/count`,
@@ -3840,7 +3932,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceTaxCodesByParentIdProductTypeExemptions(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProductTypeExemption> = {},
   ): Promise<Array<ProductTypeExemption>> {
     return this.request({
       path: `/finance/taxCodes/${parentId}/productTypeExemptions`,
@@ -3863,7 +3955,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceTaxCodesByParentIdProductTypeExemptionsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProductTypeExemption> = {},
   ): Promise<ProductTypeExemption> {
     return this.request({
       path: `/finance/taxCodes/${parentId}/productTypeExemptions/${id}`,
@@ -3908,7 +4000,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceTaxCodesByParentIdProductTypeExemptionsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/taxCodes/${parentId}/productTypeExemptions/count`,
@@ -3919,7 +4011,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceTaxCodesByParentIdTaxCodeLevels(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TaxCodeLevel> = {},
   ): Promise<Array<TaxCodeLevel>> {
     return this.request({
       path: `/finance/taxCodes/${parentId}/taxCodeLevels`,
@@ -3942,7 +4034,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceTaxCodesByParentIdTaxCodeLevelsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TaxCodeLevel> = {},
   ): Promise<TaxCodeLevel> {
     return this.request({
       path: `/finance/taxCodes/${parentId}/taxCodeLevels/${id}`,
@@ -3987,7 +4079,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceTaxCodesByParentIdTaxCodeLevelsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/taxCodes/${parentId}/taxCodeLevels/count`,
@@ -3998,7 +4090,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceTaxCodesByParentIdTaxCodeXRefs(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TaxCodeXRef> = {},
   ): Promise<Array<TaxCodeXRef>> {
     return this.request({
       path: `/finance/taxCodes/${parentId}/taxCodeXRefs`,
@@ -4021,7 +4113,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceTaxCodesByParentIdTaxCodeXRefsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TaxCodeXRef> = {},
   ): Promise<TaxCodeXRef> {
     return this.request({
       path: `/finance/taxCodes/${parentId}/taxCodeXRefs/${id}`,
@@ -4066,7 +4158,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceTaxCodesByParentIdTaxCodeXRefsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/taxCodes/${parentId}/taxCodeXRefs/count`,
@@ -4077,7 +4169,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceTaxCodesByParentIdWorkRoleExemptions(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WorkRoleExemption> = {},
   ): Promise<Array<WorkRoleExemption>> {
     return this.request({
       path: `/finance/taxCodes/${parentId}/workRoleExemptions`,
@@ -4100,7 +4192,7 @@ export class FinanceAPI extends ManageBaseAPI {
   getFinanceTaxCodesByParentIdWorkRoleExemptionsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WorkRoleExemption> = {},
   ): Promise<WorkRoleExemption> {
     return this.request({
       path: `/finance/taxCodes/${parentId}/workRoleExemptions/${id}`,
@@ -4145,7 +4237,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceTaxCodesByParentIdWorkRoleExemptionsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/finance/taxCodes/${parentId}/workRoleExemptions/count`,
@@ -4154,7 +4246,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceTaxCodesCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceTaxCodesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/taxCodes/count`,
       method: 'get',
@@ -4162,7 +4254,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceTaxCodesInfo(params: CommonParameters = {}): Promise<Array<TaxCodeInfo>> {
+  getFinanceTaxCodesInfo(params: CommonParameters<TaxCodeInfo> = {}): Promise<Array<TaxCodeInfo>> {
     return this.request({
       path: `/finance/taxCodes/info`,
       method: 'get',
@@ -4170,7 +4262,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceTaxCodesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceTaxCodesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/taxCodes/info/count`,
       method: 'get',
@@ -4178,7 +4270,9 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceTaxIntegrations(params: CommonParameters = {}): Promise<Array<TaxIntegration>> {
+  getFinanceTaxIntegrations(
+    params: CommonParameters<TaxIntegration> = {},
+  ): Promise<Array<TaxIntegration>> {
     return this.request({
       path: `/finance/taxIntegrations`,
       method: 'get',
@@ -4188,7 +4282,7 @@ export class FinanceAPI extends ManageBaseAPI {
 
   getFinanceTaxIntegrationsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TaxIntegration> = {},
   ): Promise<TaxIntegration> {
     return this.request({
       path: `/finance/taxIntegrations/${id}`,
@@ -4219,7 +4313,7 @@ export class FinanceAPI extends ManageBaseAPI {
     })
   }
 
-  getFinanceTaxIntegrationsCount(params: CommonParameters = {}): Promise<Count> {
+  getFinanceTaxIntegrationsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/finance/taxIntegrations/count`,
       method: 'get',

--- a/src/Manage/MarketingAPI.ts
+++ b/src/Manage/MarketingAPI.ts
@@ -48,7 +48,7 @@ export type Usage = schemas['Usage']
  * @public
  */
 export class MarketingAPI extends ManageBaseAPI {
-  getMarketingCampaigns(params: CommonParameters = {}): Promise<Array<Campaign>> {
+  getMarketingCampaigns(params: CommonParameters<Campaign> = {}): Promise<Array<Campaign>> {
     return this.request({
       path: `/marketing/campaigns`,
       method: 'get',
@@ -64,7 +64,10 @@ export class MarketingAPI extends ManageBaseAPI {
     })
   }
 
-  getMarketingCampaignsById(id: number, params: CommonParameters = {}): Promise<Campaign> {
+  getMarketingCampaignsById(
+    id: number,
+    params: CommonParameters<Campaign> = {},
+  ): Promise<Campaign> {
     return this.request({
       path: `/marketing/campaigns/${id}`,
       method: 'get',
@@ -100,7 +103,7 @@ export class MarketingAPI extends ManageBaseAPI {
 
   getMarketingCampaignsByIdActivities(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ActivityReference> = {},
   ): Promise<Array<ActivityReference>> {
     return this.request({
       path: `/marketing/campaigns/${id}/activities`,
@@ -111,7 +114,7 @@ export class MarketingAPI extends ManageBaseAPI {
 
   getMarketingCampaignsByIdActivitiesCount(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/marketing/campaigns/${id}/activities/count`,
@@ -122,7 +125,7 @@ export class MarketingAPI extends ManageBaseAPI {
 
   getMarketingCampaignsByIdOpportunities(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<OpportunityReference> = {},
   ): Promise<Array<OpportunityReference>> {
     return this.request({
       path: `/marketing/campaigns/${id}/opportunities`,
@@ -133,7 +136,7 @@ export class MarketingAPI extends ManageBaseAPI {
 
   getMarketingCampaignsByIdOpportunitiesCount(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/marketing/campaigns/${id}/opportunities/count`,
@@ -144,7 +147,7 @@ export class MarketingAPI extends ManageBaseAPI {
 
   getMarketingCampaignsByParentIdAudits(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CampaignAudit> = {},
   ): Promise<Array<CampaignAudit>> {
     return this.request({
       path: `/marketing/campaigns/${parentId}/audits`,
@@ -167,7 +170,7 @@ export class MarketingAPI extends ManageBaseAPI {
   getMarketingCampaignsByParentIdAuditsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CampaignAudit> = {},
   ): Promise<CampaignAudit> {
     return this.request({
       path: `/marketing/campaigns/${parentId}/audits/${id}`,
@@ -212,7 +215,7 @@ export class MarketingAPI extends ManageBaseAPI {
 
   getMarketingCampaignsByParentIdAuditsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/marketing/campaigns/${parentId}/audits/count`,
@@ -223,7 +226,7 @@ export class MarketingAPI extends ManageBaseAPI {
 
   getMarketingCampaignsByParentIdEmailsOpened(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<EmailOpened> = {},
   ): Promise<Array<EmailOpened>> {
     return this.request({
       path: `/marketing/campaigns/${parentId}/emailsOpened`,
@@ -246,7 +249,7 @@ export class MarketingAPI extends ManageBaseAPI {
   getMarketingCampaignsByParentIdEmailsOpenedById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<EmailOpened> = {},
   ): Promise<EmailOpened> {
     return this.request({
       path: `/marketing/campaigns/${parentId}/emailsOpened/${id}`,
@@ -291,7 +294,7 @@ export class MarketingAPI extends ManageBaseAPI {
 
   getMarketingCampaignsByParentIdEmailsOpenedCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/marketing/campaigns/${parentId}/emailsOpened/count`,
@@ -302,7 +305,7 @@ export class MarketingAPI extends ManageBaseAPI {
 
   getMarketingCampaignsByParentIdFormsSubmitted(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<FormSubmitted> = {},
   ): Promise<Array<FormSubmitted>> {
     return this.request({
       path: `/marketing/campaigns/${parentId}/formsSubmitted`,
@@ -325,7 +328,7 @@ export class MarketingAPI extends ManageBaseAPI {
   getMarketingCampaignsByParentIdFormsSubmittedById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<FormSubmitted> = {},
   ): Promise<FormSubmitted> {
     return this.request({
       path: `/marketing/campaigns/${parentId}/formsSubmitted/${id}`,
@@ -370,7 +373,7 @@ export class MarketingAPI extends ManageBaseAPI {
 
   getMarketingCampaignsByParentIdFormsSubmittedCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/marketing/campaigns/${parentId}/formsSubmitted/count`,
@@ -381,7 +384,7 @@ export class MarketingAPI extends ManageBaseAPI {
 
   getMarketingCampaignsByParentIdLinksClicked(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<LinkClicked> = {},
   ): Promise<Array<LinkClicked>> {
     return this.request({
       path: `/marketing/campaigns/${parentId}/linksClicked`,
@@ -404,7 +407,7 @@ export class MarketingAPI extends ManageBaseAPI {
   getMarketingCampaignsByParentIdLinksClickedById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<LinkClicked> = {},
   ): Promise<LinkClicked> {
     return this.request({
       path: `/marketing/campaigns/${parentId}/linksClicked/${id}`,
@@ -449,7 +452,7 @@ export class MarketingAPI extends ManageBaseAPI {
 
   getMarketingCampaignsByParentIdLinksClickedCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/marketing/campaigns/${parentId}/linksClicked/count`,
@@ -458,7 +461,7 @@ export class MarketingAPI extends ManageBaseAPI {
     })
   }
 
-  getMarketingCampaignsCount(params: CommonParameters = {}): Promise<Count> {
+  getMarketingCampaignsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/marketing/campaigns/count`,
       method: 'get',
@@ -466,7 +469,9 @@ export class MarketingAPI extends ManageBaseAPI {
     })
   }
 
-  getMarketingCampaignsStatuses(params: CommonParameters = {}): Promise<Array<CampaignStatus>> {
+  getMarketingCampaignsStatuses(
+    params: CommonParameters<CampaignStatus> = {},
+  ): Promise<Array<CampaignStatus>> {
     return this.request({
       path: `/marketing/campaigns/statuses`,
       method: 'get',
@@ -484,7 +489,7 @@ export class MarketingAPI extends ManageBaseAPI {
 
   getMarketingCampaignsStatusesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CampaignStatus> = {},
   ): Promise<CampaignStatus> {
     return this.request({
       path: `/marketing/campaigns/statuses/${id}`,
@@ -522,7 +527,7 @@ export class MarketingAPI extends ManageBaseAPI {
     })
   }
 
-  getMarketingCampaignsStatusesCount(params: CommonParameters = {}): Promise<Count> {
+  getMarketingCampaignsStatusesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/marketing/campaigns/statuses/count`,
       method: 'get',
@@ -531,7 +536,7 @@ export class MarketingAPI extends ManageBaseAPI {
   }
 
   getMarketingCampaignsSubTypes(
-    params: CommonParameters = {},
+    params: CommonParameters<CampaignSubTypeCampaignSubType> = {},
   ): Promise<Array<CampaignSubTypeCampaignSubType>> {
     return this.request({
       path: `/marketing/campaigns/subTypes`,
@@ -552,7 +557,7 @@ export class MarketingAPI extends ManageBaseAPI {
 
   getMarketingCampaignsSubTypesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CampaignSubTypeCampaignSubType> = {},
   ): Promise<CampaignSubTypeCampaignSubType> {
     return this.request({
       path: `/marketing/campaigns/subTypes/${id}`,
@@ -590,7 +595,7 @@ export class MarketingAPI extends ManageBaseAPI {
     })
   }
 
-  getMarketingCampaignsSubTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getMarketingCampaignsSubTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/marketing/campaigns/subTypes/count`,
       method: 'get',
@@ -598,7 +603,9 @@ export class MarketingAPI extends ManageBaseAPI {
     })
   }
 
-  getMarketingCampaignsTypes(params: CommonParameters = {}): Promise<Array<CampaignType>> {
+  getMarketingCampaignsTypes(
+    params: CommonParameters<CampaignType> = {},
+  ): Promise<Array<CampaignType>> {
     return this.request({
       path: `/marketing/campaigns/types`,
       method: 'get',
@@ -614,7 +621,10 @@ export class MarketingAPI extends ManageBaseAPI {
     })
   }
 
-  getMarketingCampaignsTypesById(id: number, params: CommonParameters = {}): Promise<CampaignType> {
+  getMarketingCampaignsTypesById(
+    id: number,
+    params: CommonParameters<CampaignType> = {},
+  ): Promise<CampaignType> {
     return this.request({
       path: `/marketing/campaigns/types/${id}`,
       method: 'get',
@@ -650,7 +660,7 @@ export class MarketingAPI extends ManageBaseAPI {
 
   getMarketingCampaignsTypesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CampaignTypeInfo> = {},
   ): Promise<CampaignTypeInfo> {
     return this.request({
       path: `/marketing/campaigns/types/${id}/info`,
@@ -661,7 +671,7 @@ export class MarketingAPI extends ManageBaseAPI {
 
   getMarketingCampaignsTypesByParentIdSubTypes(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TypeSubTypeCampaignSubType> = {},
   ): Promise<Array<TypeSubTypeCampaignSubType>> {
     return this.request({
       path: `/marketing/campaigns/types/${parentId}/subTypes`,
@@ -673,7 +683,7 @@ export class MarketingAPI extends ManageBaseAPI {
   getMarketingCampaignsTypesByParentIdSubTypesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TypeSubTypeCampaignSubType> = {},
   ): Promise<TypeSubTypeCampaignSubType> {
     return this.request({
       path: `/marketing/campaigns/types/${parentId}/subTypes/${id}`,
@@ -684,7 +694,7 @@ export class MarketingAPI extends ManageBaseAPI {
 
   getMarketingCampaignsTypesByParentIdSubTypesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/marketing/campaigns/types/${parentId}/subTypes/count`,
@@ -693,7 +703,7 @@ export class MarketingAPI extends ManageBaseAPI {
     })
   }
 
-  getMarketingCampaignsTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getMarketingCampaignsTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/marketing/campaigns/types/count`,
       method: 'get',
@@ -701,7 +711,9 @@ export class MarketingAPI extends ManageBaseAPI {
     })
   }
 
-  getMarketingCampaignsTypesInfo(params: CommonParameters = {}): Promise<Array<CampaignTypeInfo>> {
+  getMarketingCampaignsTypesInfo(
+    params: CommonParameters<CampaignTypeInfo> = {},
+  ): Promise<Array<CampaignTypeInfo>> {
     return this.request({
       path: `/marketing/campaigns/types/info`,
       method: 'get',
@@ -709,7 +721,7 @@ export class MarketingAPI extends ManageBaseAPI {
     })
   }
 
-  getMarketingCampaignsTypesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getMarketingCampaignsTypesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/marketing/campaigns/types/info/count`,
       method: 'get',
@@ -717,7 +729,7 @@ export class MarketingAPI extends ManageBaseAPI {
     })
   }
 
-  getMarketingGroups(params: CommonParameters = {}): Promise<Array<Group>> {
+  getMarketingGroups(params: CommonParameters<Group> = {}): Promise<Array<Group>> {
     return this.request({
       path: `/marketing/groups`,
       method: 'get',
@@ -733,7 +745,7 @@ export class MarketingAPI extends ManageBaseAPI {
     })
   }
 
-  getMarketingGroupsById(id: number, params: CommonParameters = {}): Promise<Group> {
+  getMarketingGroupsById(id: number, params: CommonParameters<Group> = {}): Promise<Group> {
     return this.request({
       path: `/marketing/groups/${id}`,
       method: 'get',
@@ -764,7 +776,10 @@ export class MarketingAPI extends ManageBaseAPI {
     })
   }
 
-  getMarketingGroupsByIdInfo(id: number, params: CommonParameters = {}): Promise<GroupInfo> {
+  getMarketingGroupsByIdInfo(
+    id: number,
+    params: CommonParameters<GroupInfo> = {},
+  ): Promise<GroupInfo> {
     return this.request({
       path: `/marketing/groups/${id}/info`,
       method: 'get',
@@ -772,7 +787,10 @@ export class MarketingAPI extends ManageBaseAPI {
     })
   }
 
-  getMarketingGroupsByIdUsages(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getMarketingGroupsByIdUsages(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/marketing/groups/${id}/usages`,
       method: 'get',
@@ -782,7 +800,7 @@ export class MarketingAPI extends ManageBaseAPI {
 
   getMarketingGroupsByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/marketing/groups/${id}/usages/list`,
@@ -793,7 +811,7 @@ export class MarketingAPI extends ManageBaseAPI {
 
   getMarketingGroupsByParentIdCompanies(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MarketingCompany> = {},
   ): Promise<Array<MarketingCompany>> {
     return this.request({
       path: `/marketing/groups/${parentId}/companies`,
@@ -816,7 +834,7 @@ export class MarketingAPI extends ManageBaseAPI {
   getMarketingGroupsByParentIdCompaniesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MarketingCompany> = {},
   ): Promise<MarketingCompany> {
     return this.request({
       path: `/marketing/groups/${parentId}/companies/${id}`,
@@ -861,7 +879,7 @@ export class MarketingAPI extends ManageBaseAPI {
 
   getMarketingGroupsByParentIdCompaniesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/marketing/groups/${parentId}/companies/count`,
@@ -872,7 +890,7 @@ export class MarketingAPI extends ManageBaseAPI {
 
   getMarketingGroupsByParentIdContacts(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MarketingContact> = {},
   ): Promise<Array<MarketingContact>> {
     return this.request({
       path: `/marketing/groups/${parentId}/contacts`,
@@ -895,7 +913,7 @@ export class MarketingAPI extends ManageBaseAPI {
   getMarketingGroupsByParentIdContactsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MarketingContact> = {},
   ): Promise<MarketingContact> {
     return this.request({
       path: `/marketing/groups/${parentId}/contacts/${id}`,
@@ -940,7 +958,7 @@ export class MarketingAPI extends ManageBaseAPI {
 
   getMarketingGroupsByParentIdContactsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/marketing/groups/${parentId}/contacts/count`,
@@ -949,7 +967,7 @@ export class MarketingAPI extends ManageBaseAPI {
     })
   }
 
-  getMarketingGroupsCount(params: CommonParameters = {}): Promise<Count> {
+  getMarketingGroupsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/marketing/groups/count`,
       method: 'get',
@@ -957,7 +975,7 @@ export class MarketingAPI extends ManageBaseAPI {
     })
   }
 
-  getMarketingGroupsInfo(params: CommonParameters = {}): Promise<Array<GroupInfo>> {
+  getMarketingGroupsInfo(params: CommonParameters<GroupInfo> = {}): Promise<Array<GroupInfo>> {
     return this.request({
       path: `/marketing/groups/info`,
       method: 'get',
@@ -965,7 +983,7 @@ export class MarketingAPI extends ManageBaseAPI {
     })
   }
 
-  getMarketingGroupsInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getMarketingGroupsInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/marketing/groups/info/count`,
       method: 'get',

--- a/src/Manage/ProcurementAPI.ts
+++ b/src/Manage/ProcurementAPI.ts
@@ -146,7 +146,9 @@ export type WarehouseInfo = schemas['WarehouseInfo']
  * @public
  */
 export class ProcurementAPI extends ManageBaseAPI {
-  getProcurementAdjustments(params: CommonParameters = {}): Promise<Array<ProcurementAdjustment>> {
+  getProcurementAdjustments(
+    params: CommonParameters<ProcurementAdjustment> = {},
+  ): Promise<Array<ProcurementAdjustment>> {
     return this.request({
       path: `/procurement/adjustments`,
       method: 'get',
@@ -164,7 +166,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementAdjustmentsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProcurementAdjustment> = {},
   ): Promise<ProcurementAdjustment> {
     return this.request({
       path: `/procurement/adjustments/${id}`,
@@ -204,7 +206,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementAdjustmentsByParentIdDetails(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AdjustmentDetail> = {},
   ): Promise<Array<AdjustmentDetail>> {
     return this.request({
       path: `/procurement/adjustments/${parentId}/details`,
@@ -227,7 +229,7 @@ export class ProcurementAPI extends ManageBaseAPI {
   getProcurementAdjustmentsByParentIdDetailsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AdjustmentDetail> = {},
   ): Promise<AdjustmentDetail> {
     return this.request({
       path: `/procurement/adjustments/${parentId}/details/${id}`,
@@ -248,7 +250,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementAdjustmentsByParentIdDetailsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/procurement/adjustments/${parentId}/details/count`,
@@ -257,7 +259,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementAdjustmentsCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementAdjustmentsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/adjustments/count`,
       method: 'get',
@@ -265,7 +267,9 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementAdjustmentsTypes(params: CommonParameters = {}): Promise<Array<AdjustmentType>> {
+  getProcurementAdjustmentsTypes(
+    params: CommonParameters<AdjustmentType> = {},
+  ): Promise<Array<AdjustmentType>> {
     return this.request({
       path: `/procurement/adjustments/types`,
       method: 'get',
@@ -283,7 +287,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementAdjustmentsTypesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AdjustmentType> = {},
   ): Promise<AdjustmentType> {
     return this.request({
       path: `/procurement/adjustments/types/${id}`,
@@ -323,7 +327,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementAdjustmentsTypesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AdjustmentTypeInfo> = {},
   ): Promise<AdjustmentTypeInfo> {
     return this.request({
       path: `/procurement/adjustments/types/${id}/info`,
@@ -334,7 +338,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementAdjustmentsTypesByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/procurement/adjustments/types/${id}/usages`,
@@ -345,7 +349,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementAdjustmentsTypesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/procurement/adjustments/types/${id}/usages/list`,
@@ -354,7 +358,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementAdjustmentsTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementAdjustmentsTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/adjustments/types/count`,
       method: 'get',
@@ -363,7 +367,7 @@ export class ProcurementAPI extends ManageBaseAPI {
   }
 
   getProcurementAdjustmentsTypesInfo(
-    params: CommonParameters = {},
+    params: CommonParameters<AdjustmentTypeInfo> = {},
   ): Promise<Array<AdjustmentTypeInfo>> {
     return this.request({
       path: `/procurement/adjustments/types/info`,
@@ -372,7 +376,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementAdjustmentsTypesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementAdjustmentsTypesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/adjustments/types/info/count`,
       method: 'get',
@@ -380,7 +384,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementCatalog(params: CommonParameters = {}): Promise<Array<CatalogItem>> {
+  getProcurementCatalog(params: CommonParameters<CatalogItem> = {}): Promise<Array<CatalogItem>> {
     return this.request({
       path: `/procurement/catalog`,
       method: 'get',
@@ -398,7 +402,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementCatalogByCatalogItemIdentifierQuantityOnHand(
     catalogItemIdentifier: string,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/procurement/catalog/${catalogItemIdentifier}/quantityOnHand`,
@@ -407,7 +411,10 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementCatalogById(id: number, params: CommonParameters = {}): Promise<CatalogItem> {
+  getProcurementCatalogById(
+    id: number,
+    params: CommonParameters<CatalogItem> = {},
+  ): Promise<CatalogItem> {
     return this.request({
       path: `/procurement/catalog/${id}`,
       method: 'get',
@@ -450,7 +457,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementCatalogByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CatalogItemInfo> = {},
   ): Promise<CatalogItemInfo> {
     return this.request({
       path: `/procurement/catalog/${id}/info`,
@@ -472,7 +479,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementCatalogByParentIdComponents(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CatalogComponent> = {},
   ): Promise<Array<CatalogComponent>> {
     return this.request({
       path: `/procurement/catalog/${parentId}/components`,
@@ -495,7 +502,7 @@ export class ProcurementAPI extends ManageBaseAPI {
   getProcurementCatalogByParentIdComponentsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CatalogComponent> = {},
   ): Promise<CatalogComponent> {
     return this.request({
       path: `/procurement/catalog/${parentId}/components/${id}`,
@@ -540,7 +547,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementCatalogByParentIdComponentsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/procurement/catalog/${parentId}/components/count`,
@@ -551,7 +558,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementCatalogByParentIdInventory(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CatalogInventory> = {},
   ): Promise<Array<CatalogInventory>> {
     return this.request({
       path: `/procurement/catalog/${parentId}/inventory`,
@@ -563,7 +570,7 @@ export class ProcurementAPI extends ManageBaseAPI {
   getProcurementCatalogByParentIdInventoryById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CatalogInventory> = {},
   ): Promise<CatalogInventory> {
     return this.request({
       path: `/procurement/catalog/${parentId}/inventory/${id}`,
@@ -574,7 +581,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementCatalogByParentIdInventoryCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/procurement/catalog/${parentId}/inventory/count`,
@@ -585,7 +592,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementCatalogByParentIdMinimumStockByWarehouse(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MinimumStockByWarehouse> = {},
   ): Promise<Array<MinimumStockByWarehouse>> {
     return this.request({
       path: `/procurement/catalog/${parentId}/minimumStockByWarehouse`,
@@ -608,7 +615,7 @@ export class ProcurementAPI extends ManageBaseAPI {
   getProcurementCatalogByParentIdMinimumStockByWarehouseById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MinimumStockByWarehouse> = {},
   ): Promise<MinimumStockByWarehouse> {
     return this.request({
       path: `/procurement/catalog/${parentId}/minimumStockByWarehouse/${id}`,
@@ -653,7 +660,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementCatalogByParentIdMinimumStockByWarehouseCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/procurement/catalog/${parentId}/minimumStockByWarehouse/count`,
@@ -696,7 +703,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementCatalogCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementCatalogCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/catalog/count`,
       method: 'get',
@@ -704,7 +711,9 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementCatalogInfo(params: CommonParameters = {}): Promise<Array<CatalogItemInfo>> {
+  getProcurementCatalogInfo(
+    params: CommonParameters<CatalogItemInfo> = {},
+  ): Promise<Array<CatalogItemInfo>> {
     return this.request({
       path: `/procurement/catalog/info`,
       method: 'get',
@@ -712,7 +721,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementCatalogInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementCatalogInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/catalog/info/count`,
       method: 'get',
@@ -730,7 +739,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementCatalogVendorsByParentId(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CatalogVendors> = {},
   ): Promise<Array<CatalogVendors>> {
     return this.request({
       path: `/procurement/catalog/vendors/${parentId}`,
@@ -739,7 +748,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementCategories(params: CommonParameters = {}): Promise<Array<Category>> {
+  getProcurementCategories(params: CommonParameters<Category> = {}): Promise<Array<Category>> {
     return this.request({
       path: `/procurement/categories`,
       method: 'get',
@@ -755,7 +764,10 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementCategoriesById(id: number, params: CommonParameters = {}): Promise<Category> {
+  getProcurementCategoriesById(
+    id: number,
+    params: CommonParameters<Category> = {},
+  ): Promise<Category> {
     return this.request({
       path: `/procurement/categories/${id}`,
       method: 'get',
@@ -791,7 +803,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementCategoriesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CategoryInfo> = {},
   ): Promise<CategoryInfo> {
     return this.request({
       path: `/procurement/categories/${id}/info`,
@@ -802,7 +814,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementCategoriesByParentIdSubcategories(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<LegacySubCategory> = {},
   ): Promise<Array<LegacySubCategory>> {
     return this.request({
       path: `/procurement/categories/${parentId}/subcategories/`,
@@ -825,7 +837,7 @@ export class ProcurementAPI extends ManageBaseAPI {
   getProcurementCategoriesByParentIdSubcategoriesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<LegacySubCategory> = {},
   ): Promise<LegacySubCategory> {
     return this.request({
       path: `/procurement/categories/${parentId}/subcategories/${id}`,
@@ -871,7 +883,7 @@ export class ProcurementAPI extends ManageBaseAPI {
   getProcurementCategoriesByParentIdSubcategoriesByIdInfo(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<LegacySubCategoryInfo> = {},
   ): Promise<LegacySubCategoryInfo> {
     return this.request({
       path: `/procurement/categories/${parentId}/subcategories/${id}/info`,
@@ -882,7 +894,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementCategoriesByParentIdSubcategoriesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/procurement/categories/${parentId}/subcategories/count`,
@@ -893,7 +905,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementCategoriesByParentIdSubcategoriesInfo(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<LegacySubCategoryInfo> = {},
   ): Promise<Array<LegacySubCategoryInfo>> {
     return this.request({
       path: `/procurement/categories/${parentId}/subcategories/info`,
@@ -904,7 +916,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementCategoriesByParentIdSubcategoriesInfoCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/procurement/categories/${parentId}/subcategories/info/count`,
@@ -913,7 +925,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementCategoriesCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementCategoriesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/categories/count`,
       method: 'get',
@@ -921,7 +933,9 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementCategoriesInfo(params: CommonParameters = {}): Promise<Array<CategoryInfo>> {
+  getProcurementCategoriesInfo(
+    params: CommonParameters<CategoryInfo> = {},
+  ): Promise<Array<CategoryInfo>> {
     return this.request({
       path: `/procurement/categories/info`,
       method: 'get',
@@ -929,7 +943,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementCategoriesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementCategoriesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/categories/info/count`,
       method: 'get',
@@ -937,7 +951,9 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementChangeorder(params: CommonParameters = {}): Promise<Array<ChangeOrder>> {
+  getProcurementChangeorder(
+    params: CommonParameters<ChangeOrder> = {},
+  ): Promise<Array<ChangeOrder>> {
     return this.request({
       path: `/procurement/changeorder`,
       method: 'get',
@@ -971,7 +987,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementChangeordersCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementChangeordersCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/changeorders/count`,
       method: 'get',
@@ -979,7 +995,9 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementDirectionalSyncs(params: CommonParameters = {}): Promise<Array<DirectionalSync>> {
+  getProcurementDirectionalSyncs(
+    params: CommonParameters<DirectionalSync> = {},
+  ): Promise<Array<DirectionalSync>> {
     return this.request({
       path: `/procurement/directionalSyncs`,
       method: 'get',
@@ -997,7 +1015,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementDirectionalSyncsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<DirectionalSync> = {},
   ): Promise<DirectionalSync> {
     return this.request({
       path: `/procurement/directionalSyncs/${id}`,
@@ -1035,7 +1053,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementDirectionalSyncsCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementDirectionalSyncsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/directionalSyncs/count`,
       method: 'get',
@@ -1043,7 +1061,9 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementInvoicegrouping(params: CommonParameters = {}): Promise<Array<InvoiceGrouping>> {
+  getProcurementInvoicegrouping(
+    params: CommonParameters<InvoiceGrouping> = {},
+  ): Promise<Array<InvoiceGrouping>> {
     return this.request({
       path: `/procurement/invoicegrouping`,
       method: 'get',
@@ -1053,7 +1073,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementInvoicegroupingById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<InvoiceGrouping> = {},
   ): Promise<InvoiceGrouping> {
     return this.request({
       path: `/procurement/invoicegrouping/${id}`,
@@ -1093,7 +1113,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementInvoicegroupingByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/procurement/invoicegrouping/${id}/usages`,
@@ -1104,7 +1124,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementInvoicegroupingByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/procurement/invoicegrouping/${id}/usages/list`,
@@ -1113,7 +1133,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementInvoicegroupingCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementInvoicegroupingCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/invoicegrouping/count`,
       method: 'get',
@@ -1129,7 +1149,9 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementManufacturers(params: CommonParameters = {}): Promise<Array<Manufacturer>> {
+  getProcurementManufacturers(
+    params: CommonParameters<Manufacturer> = {},
+  ): Promise<Array<Manufacturer>> {
     return this.request({
       path: `/procurement/manufacturers`,
       method: 'get',
@@ -1147,7 +1169,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementManufacturersById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Manufacturer> = {},
   ): Promise<Manufacturer> {
     return this.request({
       path: `/procurement/manufacturers/${id}`,
@@ -1184,7 +1206,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementManufacturersByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ManufacturerInfo> = {},
   ): Promise<ManufacturerInfo> {
     return this.request({
       path: `/procurement/manufacturers/${id}/info`,
@@ -1193,7 +1215,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementManufacturersCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementManufacturersCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/manufacturers/count`,
       method: 'get',
@@ -1201,7 +1223,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementManufacturersCountInfo(params: CommonParameters = {}): Promise<Count> {
+  getProcurementManufacturersCountInfo(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/manufacturers/count/info`,
       method: 'get',
@@ -1209,7 +1231,9 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementManufacturersInfo(params: CommonParameters = {}): Promise<Array<ManufacturerInfo>> {
+  getProcurementManufacturersInfo(
+    params: CommonParameters<ManufacturerInfo> = {},
+  ): Promise<Array<ManufacturerInfo>> {
     return this.request({
       path: `/procurement/manufacturers/info`,
       method: 'get',
@@ -1218,7 +1242,7 @@ export class ProcurementAPI extends ManageBaseAPI {
   }
 
   getProcurementOnhandserialnumbers(
-    params: CommonParameters = {},
+    params: CommonParameters<OnHandSerialNumber> = {},
   ): Promise<Array<OnHandSerialNumber>> {
     return this.request({
       path: `/procurement/onhandserialnumbers`,
@@ -1229,7 +1253,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementOnhandserialnumbersById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<OnHandSerialNumber> = {},
   ): Promise<OnHandSerialNumber> {
     return this.request({
       path: `/procurement/onhandserialnumbers/${id}`,
@@ -1238,7 +1262,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementOnhandserialnumbersCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementOnhandserialnumbersCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/onhandserialnumbers/count`,
       method: 'get',
@@ -1246,7 +1270,9 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementPricingschedules(params: CommonParameters = {}): Promise<Array<PricingSchedule>> {
+  getProcurementPricingschedules(
+    params: CommonParameters<PricingSchedule> = {},
+  ): Promise<Array<PricingSchedule>> {
     return this.request({
       path: `/procurement/pricingschedules`,
       method: 'get',
@@ -1265,7 +1291,7 @@ export class ProcurementAPI extends ManageBaseAPI {
   getProcurementPricingschedulesByGrandparentIdDetailsByParentIdBreaks(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PricingBreak> = {},
   ): Promise<Array<PricingBreak>> {
     return this.request({
       path: `/procurement/pricingschedules/${grandparentId}/details/${parentId}/breaks`,
@@ -1290,7 +1316,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     id: number,
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PricingBreak> = {},
   ): Promise<PricingBreak> {
     return this.request({
       path: `/procurement/pricingschedules/${grandparentId}/details/${parentId}/breaks/${id}`,
@@ -1339,7 +1365,7 @@ export class ProcurementAPI extends ManageBaseAPI {
   getProcurementPricingschedulesByGrandparentIdDetailsByParentIdBreaksCount(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/procurement/pricingschedules/${grandparentId}/details/${parentId}/breaks/count`,
@@ -1350,7 +1376,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementPricingschedulesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PricingSchedule> = {},
   ): Promise<PricingSchedule> {
     return this.request({
       path: `/procurement/pricingschedules/${id}`,
@@ -1390,7 +1416,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementPricingschedulesByParentIdDetails(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PricingDetail> = {},
   ): Promise<Array<PricingDetail>> {
     return this.request({
       path: `/procurement/pricingschedules/${parentId}/details`,
@@ -1413,7 +1439,7 @@ export class ProcurementAPI extends ManageBaseAPI {
   getProcurementPricingschedulesByParentIdDetailsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PricingDetail> = {},
   ): Promise<PricingDetail> {
     return this.request({
       path: `/procurement/pricingschedules/${parentId}/details/${id}`,
@@ -1458,7 +1484,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementPricingschedulesByParentIdDetailsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/procurement/pricingschedules/${parentId}/details/count`,
@@ -1467,7 +1493,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementPricingschedulesCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementPricingschedulesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/pricingschedules/count`,
       method: 'get',
@@ -1475,7 +1501,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementProducts(params: CommonParameters = {}): Promise<Array<ProductItem>> {
+  getProcurementProducts(params: CommonParameters<ProductItem> = {}): Promise<Array<ProductItem>> {
     return this.request({
       path: `/procurement/products`,
       method: 'get',
@@ -1491,7 +1517,10 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementProductsById(id: number, params: CommonParameters = {}): Promise<ProductItem> {
+  getProcurementProductsById(
+    id: number,
+    params: CommonParameters<ProductItem> = {},
+  ): Promise<ProductItem> {
     return this.request({
       path: `/procurement/products/${id}`,
       method: 'get',
@@ -1535,7 +1564,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementProductsByParentIdComponents(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProductComponent> = {},
   ): Promise<Array<ProductComponent>> {
     return this.request({
       path: `/procurement/products/${parentId}/components`,
@@ -1558,7 +1587,7 @@ export class ProcurementAPI extends ManageBaseAPI {
   getProcurementProductsByParentIdComponentsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProductComponent> = {},
   ): Promise<Array<ProductComponent>> {
     return this.request({
       path: `/procurement/products/${parentId}/components/${id}`,
@@ -1603,7 +1632,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementProductsByParentIdComponentsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/procurement/products/${parentId}/components/count`,
@@ -1614,7 +1643,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementProductsByParentIdPickingShippingDetails(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProductPickingShippingDetail> = {},
   ): Promise<Array<ProductPickingShippingDetail>> {
     return this.request({
       path: `/procurement/products/${parentId}/pickingShippingDetails`,
@@ -1637,7 +1666,7 @@ export class ProcurementAPI extends ManageBaseAPI {
   getProcurementProductsByParentIdPickingShippingDetailsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProductPickingShippingDetail> = {},
   ): Promise<Array<ProductPickingShippingDetail>> {
     return this.request({
       path: `/procurement/products/${parentId}/pickingShippingDetails/${id}`,
@@ -1682,7 +1711,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementProductsByParentIdPickingShippingDetailsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/procurement/products/${parentId}/pickingShippingDetails/count`,
@@ -1691,7 +1720,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementProductsCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementProductsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/products/count`,
       method: 'get',
@@ -1699,7 +1728,9 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementPurchaseorders(params: CommonParameters = {}): Promise<Array<PurchaseOrder>> {
+  getProcurementPurchaseorders(
+    params: CommonParameters<PurchaseOrder> = {},
+  ): Promise<Array<PurchaseOrder>> {
     return this.request({
       path: `/procurement/purchaseorders`,
       method: 'get',
@@ -1717,7 +1748,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementPurchaseordersById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PurchaseOrder> = {},
   ): Promise<PurchaseOrder> {
     return this.request({
       path: `/procurement/purchaseorders/${id}`,
@@ -1764,7 +1795,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementPurchaseordersByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PurchaseOrderInfo> = {},
   ): Promise<PurchaseOrderInfo> {
     return this.request({
       path: `/procurement/purchaseorders/${id}/info`,
@@ -1775,7 +1806,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementPurchaseordersByIdQuickAccessCount(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<HttpResponseMessage> = {},
   ): Promise<HttpResponseMessage> {
     return this.request({
       path: `/procurement/purchaseorders/${id}/quickAccess/count`,
@@ -1800,7 +1831,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementPurchaseordersByParentIdLineitems(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PurchaseOrderLineItem> = {},
   ): Promise<Array<PurchaseOrderLineItem>> {
     return this.request({
       path: `/procurement/purchaseorders/${parentId}/lineitems`,
@@ -1830,7 +1861,7 @@ export class ProcurementAPI extends ManageBaseAPI {
   getProcurementPurchaseordersByParentIdLineitemsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PurchaseOrderLineItem> = {},
   ): Promise<PurchaseOrderLineItem> {
     return this.request({
       path: `/procurement/purchaseorders/${parentId}/lineitems/${id}`,
@@ -1898,7 +1929,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementPurchaseordersByParentIdLineitemsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/procurement/purchaseorders/${parentId}/lineitems/count`,
@@ -1909,7 +1940,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementPurchaseordersByParentIdNotes(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PurchaseOrderNote> = {},
   ): Promise<Array<PurchaseOrderNote>> {
     return this.request({
       path: `/procurement/purchaseorders/${parentId}/notes`,
@@ -1932,7 +1963,7 @@ export class ProcurementAPI extends ManageBaseAPI {
   getProcurementPurchaseordersByParentIdNotesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PurchaseOrderNote> = {},
   ): Promise<PurchaseOrderNote> {
     return this.request({
       path: `/procurement/purchaseorders/${parentId}/notes/${id}`,
@@ -1977,7 +2008,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementPurchaseordersByParentIdNotesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/procurement/purchaseorders/${parentId}/notes/count`,
@@ -1986,7 +2017,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementPurchaseordersCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementPurchaseordersCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/purchaseorders/count`,
       method: 'get',
@@ -1995,7 +2026,7 @@ export class ProcurementAPI extends ManageBaseAPI {
   }
 
   getProcurementPurchaseordersInfo(
-    params: CommonParameters = {},
+    params: CommonParameters<PurchaseOrderInfo> = {},
   ): Promise<Array<PurchaseOrderInfo>> {
     return this.request({
       path: `/procurement/purchaseorders/info`,
@@ -2004,7 +2035,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementPurchaseordersInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementPurchaseordersInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/purchaseorders/info/count`,
       method: 'get',
@@ -2013,7 +2044,7 @@ export class ProcurementAPI extends ManageBaseAPI {
   }
 
   getProcurementPurchaseorderstatuses(
-    params: CommonParameters = {},
+    params: CommonParameters<PurchaseOrderStatus> = {},
   ): Promise<Array<PurchaseOrderStatus>> {
     return this.request({
       path: `/procurement/purchaseorderstatuses`,
@@ -2034,7 +2065,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementPurchaseorderstatusesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PurchaseOrderStatus> = {},
   ): Promise<PurchaseOrderStatus> {
     return this.request({
       path: `/procurement/purchaseorderstatuses/${id}`,
@@ -2074,7 +2105,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementPurchaseorderstatusesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PurchaseOrderStatusInfo> = {},
   ): Promise<PurchaseOrderStatusInfo> {
     return this.request({
       path: `/procurement/purchaseorderstatuses/${id}/info`,
@@ -2085,7 +2116,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementPurchaseorderstatusesByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/procurement/purchaseorderstatuses/${id}/usages`,
@@ -2096,7 +2127,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementPurchaseorderstatusesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/procurement/purchaseorderstatuses/${id}/usages/list`,
@@ -2107,7 +2138,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementPurchaseorderstatusesByParentIdEmailtemplates(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PurchaseOrderStatusEmailTemplate> = {},
   ): Promise<Array<PurchaseOrderStatusEmailTemplate>> {
     return this.request({
       path: `/procurement/purchaseorderstatuses/${parentId}/emailtemplates/`,
@@ -2130,7 +2161,7 @@ export class ProcurementAPI extends ManageBaseAPI {
   getProcurementPurchaseorderstatusesByParentIdEmailtemplatesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PurchaseOrderStatusEmailTemplate> = {},
   ): Promise<PurchaseOrderStatusEmailTemplate> {
     return this.request({
       path: `/procurement/purchaseorderstatuses/${parentId}/emailtemplates/${id}`,
@@ -2175,7 +2206,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementPurchaseorderstatusesByParentIdEmailtemplatesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/procurement/purchaseorderstatuses/${parentId}/emailtemplates/count`,
@@ -2186,7 +2217,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementPurchaseorderstatusesByParentIdNotifications(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PurchaseOrderStatusNotification> = {},
   ): Promise<Array<PurchaseOrderStatusNotification>> {
     return this.request({
       path: `/procurement/purchaseorderstatuses/${parentId}/notifications`,
@@ -2209,7 +2240,7 @@ export class ProcurementAPI extends ManageBaseAPI {
   getProcurementPurchaseorderstatusesByParentIdNotificationsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PurchaseOrderStatusNotification> = {},
   ): Promise<PurchaseOrderStatusNotification> {
     return this.request({
       path: `/procurement/purchaseorderstatuses/${parentId}/notifications/${id}`,
@@ -2254,7 +2285,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementPurchaseorderstatusesByParentIdNotificationsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/procurement/purchaseorderstatuses/${parentId}/notifications/count`,
@@ -2263,7 +2294,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementPurchaseorderstatusesCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementPurchaseorderstatusesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/purchaseorderstatuses/count`,
       method: 'get',
@@ -2272,7 +2303,7 @@ export class ProcurementAPI extends ManageBaseAPI {
   }
 
   getProcurementPurchaseorderstatusesInfo(
-    params: CommonParameters = {},
+    params: CommonParameters<PurchaseOrderStatusInfo> = {},
   ): Promise<Array<PurchaseOrderStatusInfo>> {
     return this.request({
       path: `/procurement/purchaseorderstatuses/info`,
@@ -2281,7 +2312,9 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementPurchaseorderstatusesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementPurchaseorderstatusesInfoCount(
+    params: CommonParameters<Count> = {},
+  ): Promise<Count> {
     return this.request({
       path: `/procurement/purchaseorderstatuses/Info/count`,
       method: 'get',
@@ -2297,7 +2330,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementRmaActions(params: CommonParameters = {}): Promise<Array<RmaAction>> {
+  getProcurementRmaActions(params: CommonParameters<RmaAction> = {}): Promise<Array<RmaAction>> {
     return this.request({
       path: `/procurement/rmaActions`,
       method: 'get',
@@ -2313,7 +2346,10 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementRmaActionsById(id: number, params: CommonParameters = {}): Promise<RmaAction> {
+  getProcurementRmaActionsById(
+    id: number,
+    params: CommonParameters<RmaAction> = {},
+  ): Promise<RmaAction> {
     return this.request({
       path: `/procurement/rmaActions/${id}`,
       method: 'get',
@@ -2349,7 +2385,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementRmaActionsByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<RmaActionInfo> = {},
   ): Promise<RmaActionInfo> {
     return this.request({
       path: `/procurement/rmaActions/${id}/info`,
@@ -2358,7 +2394,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementRmaActionsCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementRmaActionsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/rmaActions/count`,
       method: 'get',
@@ -2366,7 +2402,9 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementRmaActionsInfo(params: CommonParameters = {}): Promise<Array<RmaActionInfo>> {
+  getProcurementRmaActionsInfo(
+    params: CommonParameters<RmaActionInfo> = {},
+  ): Promise<Array<RmaActionInfo>> {
     return this.request({
       path: `/procurement/rmaActions/info`,
       method: 'get',
@@ -2374,7 +2412,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementRmaActionsInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementRmaActionsInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/rmaActions/info/count`,
       method: 'get',
@@ -2382,7 +2420,9 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementRMADispositions(params: CommonParameters = {}): Promise<Array<RmaDisposition>> {
+  getProcurementRMADispositions(
+    params: CommonParameters<RmaDisposition> = {},
+  ): Promise<Array<RmaDisposition>> {
     return this.request({
       path: `/procurement/RMADispositions`,
       method: 'get',
@@ -2400,7 +2440,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementRMADispositionsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<RmaDisposition> = {},
   ): Promise<RmaDisposition> {
     return this.request({
       path: `/procurement/RMADispositions/${id}`,
@@ -2440,7 +2480,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementRMADispositionsByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<RmaDispositionInfo> = {},
   ): Promise<RmaDispositionInfo> {
     return this.request({
       path: `/procurement/RMADispositions/${id}/info`,
@@ -2449,7 +2489,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementRMADispositionsCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementRMADispositionsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/RMADispositions/count`,
       method: 'get',
@@ -2458,7 +2498,7 @@ export class ProcurementAPI extends ManageBaseAPI {
   }
 
   getProcurementRMADispositionsInfo(
-    params: CommonParameters = {},
+    params: CommonParameters<RmaDispositionInfo> = {},
   ): Promise<Array<RmaDispositionInfo>> {
     return this.request({
       path: `/procurement/RMADispositions/info`,
@@ -2467,7 +2507,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementRMADispositionsInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementRMADispositionsInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/RMADispositions/info/count`,
       method: 'get',
@@ -2475,7 +2515,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementRmaStatuses(params: CommonParameters = {}): Promise<Array<RmaStatus>> {
+  getProcurementRmaStatuses(params: CommonParameters<RmaStatus> = {}): Promise<Array<RmaStatus>> {
     return this.request({
       path: `/procurement/rmaStatuses`,
       method: 'get',
@@ -2491,7 +2531,10 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementRmaStatusesById(id: number, params: CommonParameters = {}): Promise<RmaStatus> {
+  getProcurementRmaStatusesById(
+    id: number,
+    params: CommonParameters<RmaStatus> = {},
+  ): Promise<RmaStatus> {
     return this.request({
       path: `/procurement/rmaStatuses/${id}`,
       method: 'get',
@@ -2527,7 +2570,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementRmaStatusesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<RmaStatusInfo> = {},
   ): Promise<RmaStatusInfo> {
     return this.request({
       path: `/procurement/rmaStatuses/${id}/info`,
@@ -2538,7 +2581,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementRmaStatusesByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/procurement/rmaStatuses/${id}/usages`,
@@ -2549,7 +2592,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementRmaStatusesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/procurement/rmaStatuses/${id}/usages/list`,
@@ -2571,7 +2614,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementRmaStatusesByParentIdEmailTemplates(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<RmaStatusEmailTemplate> = {},
   ): Promise<Array<RmaStatusEmailTemplate>> {
     return this.request({
       path: `/procurement/rmaStatuses/${parentId}/emailTemplates/`,
@@ -2583,7 +2626,7 @@ export class ProcurementAPI extends ManageBaseAPI {
   getProcurementRmaStatusesByParentIdEmailtemplatesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<RmaStatusEmailTemplate> = {},
   ): Promise<RmaStatusEmailTemplate> {
     return this.request({
       path: `/procurement/rmaStatuses/${parentId}/emailtemplates/${id}`,
@@ -2628,7 +2671,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementRmaStatusesByParentIdEmailtemplatesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/procurement/rmaStatuses/${parentId}/emailtemplates/count`,
@@ -2639,7 +2682,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementRmaStatusesByParentIdNotifications(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<RmaStatusNotification> = {},
   ): Promise<Array<RmaStatusNotification>> {
     return this.request({
       path: `/procurement/rmaStatuses/${parentId}/notifications`,
@@ -2662,7 +2705,7 @@ export class ProcurementAPI extends ManageBaseAPI {
   getProcurementRmaStatusesByParentIdNotificationsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<RmaStatusNotification> = {},
   ): Promise<RmaStatusNotification> {
     return this.request({
       path: `/procurement/rmaStatuses/${parentId}/notifications/${id}`,
@@ -2707,7 +2750,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementRmaStatusesByParentIdNotificationsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/procurement/rmaStatuses/${parentId}/notifications/count`,
@@ -2716,7 +2759,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementRmaStatusesCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementRmaStatusesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/rmaStatuses/count`,
       method: 'get',
@@ -2724,7 +2767,9 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementRmaStatusesInfo(params: CommonParameters = {}): Promise<Array<RmaStatusInfo>> {
+  getProcurementRmaStatusesInfo(
+    params: CommonParameters<RmaStatusInfo> = {},
+  ): Promise<Array<RmaStatusInfo>> {
     return this.request({
       path: `/procurement/rmaStatuses/info`,
       method: 'get',
@@ -2732,7 +2777,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementRmaStatusesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementRmaStatusesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/rmaStatuses/info/count`,
       method: 'get',
@@ -2740,7 +2785,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementRmaTags(params: CommonParameters = {}): Promise<Array<RmaTag>> {
+  getProcurementRmaTags(params: CommonParameters<RmaTag> = {}): Promise<Array<RmaTag>> {
     return this.request({
       path: `/procurement/rmaTags`,
       method: 'get',
@@ -2756,7 +2801,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementRmaTagsById(id: number, params: CommonParameters = {}): Promise<RmaTag> {
+  getProcurementRmaTagsById(id: number, params: CommonParameters<RmaTag> = {}): Promise<RmaTag> {
     return this.request({
       path: `/procurement/rmaTags/${id}`,
       method: 'get',
@@ -2787,7 +2832,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementRmaTagsCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementRmaTagsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/rmaTags/count`,
       method: 'get',
@@ -2795,7 +2840,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementRmaTagsDefault(params: CommonParameters = {}): Promise<RmaTag> {
+  getProcurementRmaTagsDefault(params: CommonParameters<RmaTag> = {}): Promise<RmaTag> {
     return this.request({
       path: `/procurement/rmaTags/default`,
       method: 'get',
@@ -2803,7 +2848,9 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementSettings(params: CommonParameters = {}): Promise<Array<ProcurementSetting>> {
+  getProcurementSettings(
+    params: CommonParameters<ProcurementSetting> = {},
+  ): Promise<Array<ProcurementSetting>> {
     return this.request({
       path: `/procurement/settings`,
       method: 'get',
@@ -2813,7 +2860,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementSettingsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProcurementSetting> = {},
   ): Promise<ProcurementSetting> {
     return this.request({
       path: `/procurement/settings/${id}`,
@@ -2844,7 +2891,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementSettingsCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementSettingsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/settings/count`,
       method: 'get',
@@ -2852,7 +2899,9 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementShipmentmethods(params: CommonParameters = {}): Promise<Array<ShipmentMethod>> {
+  getProcurementShipmentmethods(
+    params: CommonParameters<ShipmentMethod> = {},
+  ): Promise<Array<ShipmentMethod>> {
     return this.request({
       path: `/procurement/shipmentmethods`,
       method: 'get',
@@ -2870,7 +2919,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementShipmentmethodsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ShipmentMethod> = {},
   ): Promise<ShipmentMethod> {
     return this.request({
       path: `/procurement/shipmentmethods/${id}`,
@@ -2910,7 +2959,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementShipmentmethodsByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ShipmentMethodInfo> = {},
   ): Promise<ShipmentMethodInfo> {
     return this.request({
       path: `/procurement/shipmentmethods/${id}/info`,
@@ -2921,7 +2970,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementShipmentmethodsByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/procurement/shipmentmethods/${id}/usages`,
@@ -2932,7 +2981,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementShipmentmethodsByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/procurement/shipmentmethods/${id}/usages/list`,
@@ -2941,7 +2990,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementShipmentmethodsCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementShipmentmethodsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/shipmentmethods/count`,
       method: 'get',
@@ -2950,7 +2999,7 @@ export class ProcurementAPI extends ManageBaseAPI {
   }
 
   getProcurementShipmentmethodsInfo(
-    params: CommonParameters = {},
+    params: CommonParameters<ShipmentMethodInfo> = {},
   ): Promise<Array<ShipmentMethodInfo>> {
     return this.request({
       path: `/procurement/shipmentmethods/info`,
@@ -2959,7 +3008,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementShipmentmethodsInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementShipmentmethodsInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/shipmentmethods/info/count`,
       method: 'get',
@@ -2967,7 +3016,9 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementSubcategories(params: CommonParameters = {}): Promise<Array<SubCategory>> {
+  getProcurementSubcategories(
+    params: CommonParameters<SubCategory> = {},
+  ): Promise<Array<SubCategory>> {
     return this.request({
       path: `/procurement/subcategories/`,
       method: 'get',
@@ -2983,7 +3034,10 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementSubcategoriesById(id: number, params: CommonParameters = {}): Promise<SubCategory> {
+  getProcurementSubcategoriesById(
+    id: number,
+    params: CommonParameters<SubCategory> = {},
+  ): Promise<SubCategory> {
     return this.request({
       path: `/procurement/subcategories/${id}`,
       method: 'get',
@@ -3019,7 +3073,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementSubcategoriesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<SubCategoryInfo> = {},
   ): Promise<SubCategoryInfo> {
     return this.request({
       path: `/procurement/subcategories/${id}/info`,
@@ -3030,7 +3084,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementSubcategoriesByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/procurement/subcategories/${id}/usages`,
@@ -3041,7 +3095,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementSubcategoriesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/procurement/subcategories/${id}/usages/list`,
@@ -3050,7 +3104,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementSubcategoriesCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementSubcategoriesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/subcategories/count`,
       method: 'get',
@@ -3058,7 +3112,9 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementSubcategoriesInfo(params: CommonParameters = {}): Promise<Array<SubCategoryInfo>> {
+  getProcurementSubcategoriesInfo(
+    params: CommonParameters<SubCategoryInfo> = {},
+  ): Promise<Array<SubCategoryInfo>> {
     return this.request({
       path: `/procurement/subcategories/info/`,
       method: 'get',
@@ -3066,7 +3122,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementSubcategoriesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementSubcategoriesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/subcategories/info/count`,
       method: 'get',
@@ -3074,7 +3130,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementTypes(params: CommonParameters = {}): Promise<Array<ProductType>> {
+  getProcurementTypes(params: CommonParameters<ProductType> = {}): Promise<Array<ProductType>> {
     return this.request({
       path: `/procurement/types`,
       method: 'get',
@@ -3090,7 +3146,10 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementTypesById(id: number, params: CommonParameters = {}): Promise<ProductType> {
+  getProcurementTypesById(
+    id: number,
+    params: CommonParameters<ProductType> = {},
+  ): Promise<ProductType> {
     return this.request({
       path: `/procurement/types/${id}`,
       method: 'get',
@@ -3124,7 +3183,10 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementTypesByIdInfo(id: number, params: CommonParameters = {}): Promise<ProductTypeInfo> {
+  getProcurementTypesByIdInfo(
+    id: number,
+    params: CommonParameters<ProductTypeInfo> = {},
+  ): Promise<ProductTypeInfo> {
     return this.request({
       path: `/procurement/types/${id}/info`,
       method: 'get',
@@ -3132,7 +3194,10 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementTypesByIdUsages(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getProcurementTypesByIdUsages(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/procurement/types/${id}/usages`,
       method: 'get',
@@ -3142,7 +3207,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementTypesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/procurement/types/${id}/usages/list`,
@@ -3151,7 +3216,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/types/count`,
       method: 'get',
@@ -3159,7 +3224,9 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementTypesInfo(params: CommonParameters = {}): Promise<Array<ProductTypeInfo>> {
+  getProcurementTypesInfo(
+    params: CommonParameters<ProductTypeInfo> = {},
+  ): Promise<Array<ProductTypeInfo>> {
     return this.request({
       path: `/procurement/types/info`,
       method: 'get',
@@ -3167,7 +3234,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementTypesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementTypesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/types/info/count`,
       method: 'get',
@@ -3175,7 +3242,9 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementUnitOfMeasures(params: CommonParameters = {}): Promise<Array<UnitOfMeasure>> {
+  getProcurementUnitOfMeasures(
+    params: CommonParameters<UnitOfMeasure> = {},
+  ): Promise<Array<UnitOfMeasure>> {
     return this.request({
       path: `/procurement/unitOfMeasures`,
       method: 'get',
@@ -3193,7 +3262,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementUnitOfMeasuresById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<UnitOfMeasure> = {},
   ): Promise<UnitOfMeasure> {
     return this.request({
       path: `/procurement/unitOfMeasures/${id}`,
@@ -3233,7 +3302,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementUnitOfMeasuresByParentIdConversions(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Conversion> = {},
   ): Promise<Array<Conversion>> {
     return this.request({
       path: `/procurement/unitOfMeasures/${parentId}/conversions`,
@@ -3256,7 +3325,7 @@ export class ProcurementAPI extends ManageBaseAPI {
   getProcurementUnitOfMeasuresByParentIdConversionsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Conversion> = {},
   ): Promise<Conversion> {
     return this.request({
       path: `/procurement/unitOfMeasures/${parentId}/conversions/${id}`,
@@ -3301,7 +3370,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementUnitOfMeasuresByParentIdConversionsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/procurement/unitOfMeasures/${parentId}/conversions/count`,
@@ -3310,7 +3379,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementUnitOfMeasuresCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementUnitOfMeasuresCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/unitOfMeasures/count`,
       method: 'get',
@@ -3318,7 +3387,9 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementWarehouseBins(params: CommonParameters = {}): Promise<Array<WarehouseBin>> {
+  getProcurementWarehouseBins(
+    params: CommonParameters<WarehouseBin> = {},
+  ): Promise<Array<WarehouseBin>> {
     return this.request({
       path: `/procurement/warehouseBins`,
       method: 'get',
@@ -3336,7 +3407,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementWarehouseBinsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WarehouseBin> = {},
   ): Promise<WarehouseBin> {
     return this.request({
       path: `/procurement/warehouseBins/${id}`,
@@ -3373,7 +3444,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementWarehouseBinsByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WarehouseBinInfo> = {},
   ): Promise<WarehouseBinInfo> {
     return this.request({
       path: `/procurement/warehouseBins/${id}/info`,
@@ -3384,7 +3455,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementWarehouseBinsByParentIdInventoryOnHand(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<InventoryOnHand> = {},
   ): Promise<Array<InventoryOnHand>> {
     return this.request({
       path: `/procurement/warehouseBins/${parentId}/inventoryOnHand`,
@@ -3396,7 +3467,7 @@ export class ProcurementAPI extends ManageBaseAPI {
   getProcurementWarehouseBinsByParentIdInventoryOnHandById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<InventoryOnHand> = {},
   ): Promise<InventoryOnHand> {
     return this.request({
       path: `/procurement/warehouseBins/${parentId}/inventoryOnHand/${id}`,
@@ -3407,7 +3478,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementWarehouseBinsByParentIdInventoryOnHandCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/procurement/warehouseBins/${parentId}/inventoryOnHand/count`,
@@ -3416,7 +3487,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementWarehouseBinsCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementWarehouseBinsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/warehouseBins/count`,
       method: 'get',
@@ -3424,7 +3495,9 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementWarehouseBinsInfo(params: CommonParameters = {}): Promise<Array<WarehouseBinInfo>> {
+  getProcurementWarehouseBinsInfo(
+    params: CommonParameters<WarehouseBinInfo> = {},
+  ): Promise<Array<WarehouseBinInfo>> {
     return this.request({
       path: `/procurement/warehouseBins/info`,
       method: 'get',
@@ -3432,7 +3505,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementWarehouseBinsInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementWarehouseBinsInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/warehouseBins/info/count`,
       method: 'get',
@@ -3440,7 +3513,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementWarehouses(params: CommonParameters = {}): Promise<Array<Warehouse>> {
+  getProcurementWarehouses(params: CommonParameters<Warehouse> = {}): Promise<Array<Warehouse>> {
     return this.request({
       path: `/procurement/warehouses`,
       method: 'get',
@@ -3456,7 +3529,10 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementWarehousesById(id: number, params: CommonParameters = {}): Promise<Warehouse> {
+  getProcurementWarehousesById(
+    id: number,
+    params: CommonParameters<Warehouse> = {},
+  ): Promise<Warehouse> {
     return this.request({
       path: `/procurement/warehouses/${id}`,
       method: 'get',
@@ -3492,7 +3568,7 @@ export class ProcurementAPI extends ManageBaseAPI {
 
   getProcurementWarehousesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WarehouseInfo> = {},
   ): Promise<WarehouseInfo> {
     return this.request({
       path: `/procurement/warehouses/${id}/info`,
@@ -3501,7 +3577,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementWarehousesCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementWarehousesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/warehouses/count`,
       method: 'get',
@@ -3509,7 +3585,9 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementWarehousesInfo(params: CommonParameters = {}): Promise<Array<WarehouseInfo>> {
+  getProcurementWarehousesInfo(
+    params: CommonParameters<WarehouseInfo> = {},
+  ): Promise<Array<WarehouseInfo>> {
     return this.request({
       path: `/procurement/warehouses/info`,
       method: 'get',
@@ -3517,7 +3595,7 @@ export class ProcurementAPI extends ManageBaseAPI {
     })
   }
 
-  getProcurementWarehousesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getProcurementWarehousesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/procurement/warehouses/info/count`,
       method: 'get',

--- a/src/Manage/ProjectAPI.ts
+++ b/src/Manage/ProjectAPI.ts
@@ -98,7 +98,7 @@ export type Usage = schemas['Usage']
 export class ProjectAPI extends ManageBaseAPI {
   getProjectByParentIdBillingRates(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectBillingRate> = {},
   ): Promise<Array<ProjectBillingRate>> {
     return this.request({
       path: `/project/${parentId}/billingRates`,
@@ -121,7 +121,7 @@ export class ProjectAPI extends ManageBaseAPI {
   getProjectByParentIdBillingRatesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectBillingRate> = {},
   ): Promise<ProjectBillingRate> {
     return this.request({
       path: `/project/${parentId}/billingRates/${id}`,
@@ -154,7 +154,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectByParentIdBillingRatesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/project/${parentId}/billingRates/count`,
@@ -178,7 +178,7 @@ export class ProjectAPI extends ManageBaseAPI {
   getProjectBoardsByGrandparentIdTeamsByParentIdMembers(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectBoardTeamMember> = {},
   ): Promise<Array<ProjectBoardTeamMember>> {
     return this.request({
       path: `/project/boards/${grandparentId}/teams/${parentId}/members`,
@@ -203,7 +203,7 @@ export class ProjectAPI extends ManageBaseAPI {
     id: number,
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectBoardTeamMember> = {},
   ): Promise<ProjectBoardTeamMember> {
     return this.request({
       path: `/project/boards/${grandparentId}/teams/${parentId}/members/${id}`,
@@ -251,7 +251,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectBoardsByParentIdKanbanSettings(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectBoardKanbanSetting> = {},
   ): Promise<Array<ProjectBoardKanbanSetting>> {
     return this.request({
       path: `/project/boards/${parentId}/kanbanSettings`,
@@ -274,7 +274,7 @@ export class ProjectAPI extends ManageBaseAPI {
   getProjectBoardsByParentIdKanbanSettingsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectBoardKanbanSetting> = {},
   ): Promise<ProjectBoardKanbanSetting> {
     return this.request({
       path: `/project/boards/${parentId}/kanbanSettings/${id}`,
@@ -319,7 +319,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectBoardsByParentIdTeams(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectBoardTeam> = {},
   ): Promise<Array<ProjectBoardTeam>> {
     return this.request({
       path: `/project/boards/${parentId}/teams`,
@@ -342,7 +342,7 @@ export class ProjectAPI extends ManageBaseAPI {
   getProjectBoardsByParentIdTeamsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectBoardTeam> = {},
   ): Promise<ProjectBoardTeam> {
     return this.request({
       path: `/project/boards/${parentId}/teams/${id}`,
@@ -385,7 +385,7 @@ export class ProjectAPI extends ManageBaseAPI {
   getProjectBoardsByParentIdTeamsByIdInfo(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectBoardTeamInfo> = {},
   ): Promise<ProjectBoardTeamInfo> {
     return this.request({
       path: `/project/boards/${parentId}/teams/${id}/info`,
@@ -397,7 +397,7 @@ export class ProjectAPI extends ManageBaseAPI {
   getProjectBoardsByParentIdTeamsByIdInfoCount(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/project/boards/${parentId}/teams/${id}/info/count`,
@@ -408,7 +408,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectBoardsByParentIdTeamsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/project/boards/${parentId}/teams/count`,
@@ -419,7 +419,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectBoardsByParentIdTeamsInfo(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectBoardTeamInfo> = {},
   ): Promise<Array<ProjectBoardTeamInfo>> {
     return this.request({
       path: `/project/boards/${parentId}/teams/info`,
@@ -428,7 +428,7 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectPhaseStatuses(params: CommonParameters = {}): Promise<Array<PhaseStatus>> {
+  getProjectPhaseStatuses(params: CommonParameters<PhaseStatus> = {}): Promise<Array<PhaseStatus>> {
     return this.request({
       path: `/project/phaseStatuses`,
       method: 'get',
@@ -444,7 +444,10 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectPhaseStatusesById(id: number, params: CommonParameters = {}): Promise<PhaseStatus> {
+  getProjectPhaseStatusesById(
+    id: number,
+    params: CommonParameters<PhaseStatus> = {},
+  ): Promise<PhaseStatus> {
     return this.request({
       path: `/project/phaseStatuses/${id}`,
       method: 'get',
@@ -480,7 +483,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectPhaseStatusesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PhaseStatusInfo> = {},
   ): Promise<PhaseStatusInfo> {
     return this.request({
       path: `/project/phaseStatuses/${id}/info`,
@@ -491,7 +494,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectPhaseStatusesByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/project/phaseStatuses/${id}/usages`,
@@ -502,7 +505,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectPhaseStatusesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/project/phaseStatuses/${id}/usages/list`,
@@ -511,7 +514,7 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectPhaseStatusesCount(params: CommonParameters = {}): Promise<Count> {
+  getProjectPhaseStatusesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/project/phaseStatuses/count`,
       method: 'get',
@@ -519,7 +522,9 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectPhaseStatusesInfo(params: CommonParameters = {}): Promise<Array<PhaseStatusInfo>> {
+  getProjectPhaseStatusesInfo(
+    params: CommonParameters<PhaseStatusInfo> = {},
+  ): Promise<Array<PhaseStatusInfo>> {
     return this.request({
       path: `/project/phaseStatuses/info`,
       method: 'get',
@@ -527,7 +532,7 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectProjects(params: CommonParameters = {}): Promise<Array<Project>> {
+  getProjectProjects(params: CommonParameters<Project> = {}): Promise<Array<Project>> {
     return this.request({
       path: `/project/projects`,
       method: 'get',
@@ -543,7 +548,7 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectProjectsById(id: number, params: CommonParameters = {}): Promise<Project> {
+  getProjectProjectsById(id: number, params: CommonParameters<Project> = {}): Promise<Project> {
     return this.request({
       path: `/project/projects/${id}`,
       method: 'get',
@@ -576,7 +581,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectProjectsByIdProjectRecap(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectRecap> = {},
   ): Promise<ProjectRecap> {
     return this.request({
       path: `/project/projects/${id}/projectRecap`,
@@ -587,7 +592,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectProjectsByIdProjectWorkplan(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectWorkplan> = {},
   ): Promise<ProjectWorkplan> {
     return this.request({
       path: `/project/projects/${id}/projectWorkplan`,
@@ -619,7 +624,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectProjectsByParentIdContacts(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectContact> = {},
   ): Promise<Array<ProjectContact>> {
     return this.request({
       path: `/project/projects/${parentId}/contacts`,
@@ -642,7 +647,7 @@ export class ProjectAPI extends ManageBaseAPI {
   getProjectProjectsByParentIdContactsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectContact> = {},
   ): Promise<ProjectContact> {
     return this.request({
       path: `/project/projects/${parentId}/contacts/${id}`,
@@ -663,7 +668,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectProjectsByParentIdNotes(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectNote> = {},
   ): Promise<Array<ProjectNote>> {
     return this.request({
       path: `/project/projects/${parentId}/notes`,
@@ -683,7 +688,7 @@ export class ProjectAPI extends ManageBaseAPI {
   getProjectProjectsByParentIdNotesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectNote> = {},
   ): Promise<ProjectNote> {
     return this.request({
       path: `/project/projects/${parentId}/notes/${id}`,
@@ -728,7 +733,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectProjectsByParentIdNotesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/project/projects/${parentId}/notes/count`,
@@ -739,7 +744,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectProjectsByParentIdPhases(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectPhase> = {},
   ): Promise<Array<ProjectPhase>> {
     return this.request({
       path: `/project/projects/${parentId}/phases`,
@@ -762,7 +767,7 @@ export class ProjectAPI extends ManageBaseAPI {
   getProjectProjectsByParentIdPhasesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectPhase> = {},
   ): Promise<ProjectPhase> {
     return this.request({
       path: `/project/projects/${parentId}/phases/${id}`,
@@ -807,7 +812,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectProjectsByParentIdPhasesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/project/projects/${parentId}/phases/count`,
@@ -818,7 +823,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectProjectsByParentIdTeamMembers(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectTeamMember> = {},
   ): Promise<Array<ProjectTeamMember>> {
     return this.request({
       path: `/project/projects/${parentId}/teamMembers`,
@@ -841,7 +846,7 @@ export class ProjectAPI extends ManageBaseAPI {
   getProjectProjectsByParentIdTeamMembersById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectTeamMember> = {},
   ): Promise<ProjectTeamMember> {
     return this.request({
       path: `/project/projects/${parentId}/teamMembers/${id}`,
@@ -886,7 +891,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectProjectsByParentIdTeamMembersCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/project/projects/${parentId}/teamMembers/count`,
@@ -895,7 +900,7 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectProjectsCount(params: CommonParameters = {}): Promise<Count> {
+  getProjectProjectsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/project/projects/count`,
       method: 'get',
@@ -903,7 +908,9 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectProjectTemplates(params: CommonParameters = {}): Promise<Array<ProjectTemplate>> {
+  getProjectProjectTemplates(
+    params: CommonParameters<ProjectTemplate> = {},
+  ): Promise<Array<ProjectTemplate>> {
     return this.request({
       path: `/project/projectTemplates/`,
       method: 'get',
@@ -922,7 +929,7 @@ export class ProjectAPI extends ManageBaseAPI {
   getProjectProjectTemplatesByGrandParentIdProjectTemplateTicketsByParentIdTasks(
     grandParentId: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectTemplateTask> = {},
   ): Promise<Array<ProjectTemplateTask>> {
     return this.request({
       path: `/project/projectTemplates/${grandParentId}/projectTemplateTickets/${parentId}/tasks`,
@@ -947,7 +954,7 @@ export class ProjectAPI extends ManageBaseAPI {
     id: number,
     grandParentId: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectTemplateTask> = {},
   ): Promise<ProjectTemplateTask> {
     return this.request({
       path: `/project/projectTemplates/${grandParentId}/projectTemplateTickets/${parentId}/tasks/${id}`,
@@ -996,7 +1003,7 @@ export class ProjectAPI extends ManageBaseAPI {
   getProjectProjectTemplatesByGrandParentIdProjectTemplateTicketsByParentIdTasksCount(
     grandParentId: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/project/projectTemplates/${grandParentId}/projectTemplateTickets/${parentId}/tasks/count`,
@@ -1007,7 +1014,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectProjectTemplatesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectTemplate> = {},
   ): Promise<ProjectTemplate> {
     return this.request({
       path: `/project/projectTemplates/${id}`,
@@ -1047,7 +1054,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectProjectTemplatesByIdWorkplan(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectTemplateWorkPlan> = {},
   ): Promise<Array<ProjectTemplateWorkPlan>> {
     return this.request({
       path: `/project/projectTemplates/${id}/workplan`,
@@ -1058,7 +1065,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectProjectTemplatesByParentIdProjectTemplatePhases(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectTemplatePhase> = {},
   ): Promise<Array<ProjectTemplatePhase>> {
     return this.request({
       path: `/project/projectTemplates/${parentId}/projectTemplatePhases`,
@@ -1081,7 +1088,7 @@ export class ProjectAPI extends ManageBaseAPI {
   getProjectProjectTemplatesByParentIdProjectTemplatePhasesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectTemplatePhase> = {},
   ): Promise<ProjectTemplatePhase> {
     return this.request({
       path: `/project/projectTemplates/${parentId}/projectTemplatePhases/${id}`,
@@ -1126,7 +1133,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectProjectTemplatesByParentIdProjectTemplateTickets(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectTemplateTicket> = {},
   ): Promise<Array<ProjectTemplateTicket>> {
     return this.request({
       path: `/project/projectTemplates/${parentId}/projectTemplateTickets`,
@@ -1149,7 +1156,7 @@ export class ProjectAPI extends ManageBaseAPI {
   getProjectProjectTemplatesByParentIdProjectTemplateTicketsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectTemplateTicket> = {},
   ): Promise<ProjectTemplateTicket> {
     return this.request({
       path: `/project/projectTemplates/${parentId}/projectTemplateTickets/${id}`,
@@ -1194,7 +1201,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectProjectTemplatesByParentIdProjectTemplateTicketsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/project/projectTemplates/${parentId}/projectTemplateTickets/count`,
@@ -1203,7 +1210,7 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectProjectTemplatesCount(params: CommonParameters = {}): Promise<Count> {
+  getProjectProjectTemplatesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/project/projectTemplates/count`,
       method: 'get',
@@ -1223,7 +1230,7 @@ export class ProjectAPI extends ManageBaseAPI {
   }
 
   getProjectProjectTemplatesProjectTemplatePhases(
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectTemplatePhase> = {},
   ): Promise<Array<ProjectTemplatePhase>> {
     return this.request({
       path: `/project/projectTemplates/projectTemplatePhases`,
@@ -1233,7 +1240,7 @@ export class ProjectAPI extends ManageBaseAPI {
   }
 
   getProjectProjectTemplatesProjectTemplateTickets(
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectTemplateTicket> = {},
   ): Promise<Array<ProjectTemplateTicket>> {
     return this.request({
       path: `/project/projectTemplates/projectTemplateTickets`,
@@ -1243,7 +1250,7 @@ export class ProjectAPI extends ManageBaseAPI {
   }
 
   getProjectProjectTemplatesProjectTemplateTicketsTasks(
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectTemplateTask> = {},
   ): Promise<Array<ProjectTemplateTask>> {
     return this.request({
       path: `/project/projectTemplates/projectTemplateTickets/tasks`,
@@ -1252,7 +1259,7 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectProjectTypes(params: CommonParameters = {}): Promise<Array<ProjectType>> {
+  getProjectProjectTypes(params: CommonParameters<ProjectType> = {}): Promise<Array<ProjectType>> {
     return this.request({
       path: `/project/projectTypes`,
       method: 'get',
@@ -1268,7 +1275,10 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectProjectTypesById(id: number, params: CommonParameters = {}): Promise<ProjectType> {
+  getProjectProjectTypesById(
+    id: number,
+    params: CommonParameters<ProjectType> = {},
+  ): Promise<ProjectType> {
     return this.request({
       path: `/project/projectTypes/${id}`,
       method: 'get',
@@ -1304,7 +1314,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectProjectTypesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectTypeInfo> = {},
   ): Promise<ProjectTypeInfo> {
     return this.request({
       path: `/project/projectTypes/${id}/info`,
@@ -1315,7 +1325,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectProjectTypesByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/project/projectTypes/${id}/usages`,
@@ -1326,7 +1336,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectProjectTypesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/project/projectTypes/${id}/usages/list`,
@@ -1335,7 +1345,7 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectProjectTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getProjectProjectTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/project/projectTypes/count`,
       method: 'get',
@@ -1343,7 +1353,9 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectProjectTypesInfo(params: CommonParameters = {}): Promise<Array<ProjectTypeInfo>> {
+  getProjectProjectTypesInfo(
+    params: CommonParameters<ProjectTypeInfo> = {},
+  ): Promise<Array<ProjectTypeInfo>> {
     return this.request({
       path: `/project/projectTypes/info`,
       method: 'get',
@@ -1351,7 +1363,7 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectProjectTypesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getProjectProjectTypesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/project/projectTypes/info/count`,
       method: 'get',
@@ -1359,7 +1371,9 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectSecurityRoles(params: CommonParameters = {}): Promise<Array<ProjectSecurityRole>> {
+  getProjectSecurityRoles(
+    params: CommonParameters<ProjectSecurityRole> = {},
+  ): Promise<Array<ProjectSecurityRole>> {
     return this.request({
       path: `/project/securityRoles`,
       method: 'get',
@@ -1377,7 +1391,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectSecurityRolesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectSecurityRole> = {},
   ): Promise<ProjectSecurityRole> {
     return this.request({
       path: `/project/securityRoles/${id}`,
@@ -1417,7 +1431,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectSecurityRolesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectSecurityRoleInfo> = {},
   ): Promise<ProjectSecurityRoleInfo> {
     return this.request({
       path: `/project/securityRoles/${id}/info`,
@@ -1428,7 +1442,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectSecurityRolesByParentIdSettings(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectSecurityRoleSetting> = {},
   ): Promise<Array<ProjectSecurityRoleSetting>> {
     return this.request({
       path: `/project/securityRoles/${parentId}/settings`,
@@ -1440,7 +1454,7 @@ export class ProjectAPI extends ManageBaseAPI {
   getProjectSecurityRolesByParentIdSettingsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectSecurityRoleSetting> = {},
   ): Promise<ProjectSecurityRoleSetting> {
     return this.request({
       path: `/project/securityRoles/${parentId}/settings/${id}`,
@@ -1475,7 +1489,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectSecurityRolesByParentIdSettingsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/project/securityRoles/${parentId}/settings/count`,
@@ -1484,7 +1498,7 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectSecurityRolesCount(params: CommonParameters = {}): Promise<Count> {
+  getProjectSecurityRolesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/project/securityRoles/count`,
       method: 'get',
@@ -1493,7 +1507,7 @@ export class ProjectAPI extends ManageBaseAPI {
   }
 
   getProjectSecurityRolesInfo(
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectSecurityRoleInfo> = {},
   ): Promise<Array<ProjectSecurityRoleInfo>> {
     return this.request({
       path: `/project/securityRoles/info`,
@@ -1502,7 +1516,7 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectStatuses(params: CommonParameters = {}): Promise<Array<ProjectStatus>> {
+  getProjectStatuses(params: CommonParameters<ProjectStatus> = {}): Promise<Array<ProjectStatus>> {
     return this.request({
       path: `/project/statuses`,
       method: 'get',
@@ -1518,7 +1532,10 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectStatusesById(id: number, params: CommonParameters = {}): Promise<ProjectStatus> {
+  getProjectStatusesById(
+    id: number,
+    params: CommonParameters<ProjectStatus> = {},
+  ): Promise<ProjectStatus> {
     return this.request({
       path: `/project/statuses/${id}`,
       method: 'get',
@@ -1554,7 +1571,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectStatusesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectStatusInfo> = {},
   ): Promise<ProjectStatusInfo> {
     return this.request({
       path: `/project/statuses/${id}/info`,
@@ -1563,7 +1580,10 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectStatusesByIdUsages(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getProjectStatusesByIdUsages(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/project/statuses/${id}/usages`,
       method: 'get',
@@ -1573,7 +1593,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectStatusesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/project/statuses/${id}/usages/list`,
@@ -1582,7 +1602,7 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectStatusesCount(params: CommonParameters = {}): Promise<Count> {
+  getProjectStatusesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/project/statuses/count`,
       method: 'get',
@@ -1590,7 +1610,9 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectStatusesInfo(params: CommonParameters = {}): Promise<Array<ProjectStatusInfo>> {
+  getProjectStatusesInfo(
+    params: CommonParameters<ProjectStatusInfo> = {},
+  ): Promise<Array<ProjectStatusInfo>> {
     return this.request({
       path: `/project/statuses/info`,
       method: 'get',
@@ -1598,7 +1620,7 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectStatusesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getProjectStatusesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/project/statuses/info/count`,
       method: 'get',
@@ -1606,7 +1628,9 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectStatusIndicators(params: CommonParameters = {}): Promise<Array<StatusIndicator>> {
+  getProjectStatusIndicators(
+    params: CommonParameters<StatusIndicator> = {},
+  ): Promise<Array<StatusIndicator>> {
     return this.request({
       path: `/project/statusIndicators`,
       method: 'get',
@@ -1616,7 +1640,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectStatusIndicatorsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<StatusIndicator> = {},
   ): Promise<StatusIndicator> {
     return this.request({
       path: `/project/statusIndicators/${id}`,
@@ -1625,7 +1649,7 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectStatusIndicatorsCount(params: CommonParameters = {}): Promise<Count> {
+  getProjectStatusIndicatorsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/project/statusIndicators/count`,
       method: 'get',
@@ -1641,7 +1665,7 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectTickets(params: CommonParameters = {}): Promise<Array<ProjectTicket>> {
+  getProjectTickets(params: CommonParameters<ProjectTicket> = {}): Promise<Array<ProjectTicket>> {
     return this.request({
       path: `/project/tickets`,
       method: 'get',
@@ -1657,7 +1681,10 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectTicketsById(id: number, params: CommonParameters = {}): Promise<ProjectTicket> {
+  getProjectTicketsById(
+    id: number,
+    params: CommonParameters<ProjectTicket> = {},
+  ): Promise<ProjectTicket> {
     return this.request({
       path: `/project/tickets/${id}`,
       method: 'get',
@@ -1693,7 +1720,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectTicketsByParentIdActivities(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ActivityReference> = {},
   ): Promise<Array<ActivityReference>> {
     return this.request({
       path: `/project/tickets/${parentId}/activities`,
@@ -1704,7 +1731,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectTicketsByParentIdActivitiesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/project/tickets/${parentId}/activities/count`,
@@ -1715,7 +1742,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectTicketsByParentIdAllNotes(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProjectTicketNote> = {},
   ): Promise<Array<ProjectTicketNote>> {
     return this.request({
       path: `/project/tickets/${parentId}/allNotes`,
@@ -1726,7 +1753,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectTicketsByParentIdConfigurations(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ConfigurationReference> = {},
   ): Promise<Array<ConfigurationReference>> {
     return this.request({
       path: `/project/tickets/${parentId}/configurations`,
@@ -1749,7 +1776,7 @@ export class ProjectAPI extends ManageBaseAPI {
   getProjectTicketsByParentIdConfigurationsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ConfigurationReference> = {},
   ): Promise<ConfigurationReference> {
     return this.request({
       path: `/project/tickets/${parentId}/configurations/${id}`,
@@ -1770,7 +1797,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectTicketsByParentIdConfigurationsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/project/tickets/${parentId}/configurations/count`,
@@ -1792,7 +1819,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectTicketsByParentIdDocuments(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<DocumentReference> = {},
   ): Promise<Array<DocumentReference>> {
     return this.request({
       path: `/project/tickets/${parentId}/documents`,
@@ -1803,7 +1830,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectTicketsByParentIdDocumentsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/project/tickets/${parentId}/documents/count`,
@@ -1814,7 +1841,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectTicketsByParentIdNotes(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TicketNote> = {},
   ): Promise<Array<TicketNote>> {
     return this.request({
       path: `/project/tickets/${parentId}/notes`,
@@ -1834,7 +1861,7 @@ export class ProjectAPI extends ManageBaseAPI {
   getProjectTicketsByParentIdNotesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TicketNote> = {},
   ): Promise<TicketNote> {
     return this.request({
       path: `/project/tickets/${parentId}/notes/${id}`,
@@ -1879,7 +1906,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectTicketsByParentIdNotesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/project/tickets/${parentId}/notes/count`,
@@ -1890,7 +1917,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectTicketsByParentIdProducts(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProductReference> = {},
   ): Promise<Array<ProductReference>> {
     return this.request({
       path: `/project/tickets/${parentId}/products`,
@@ -1901,7 +1928,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectTicketsByParentIdProductsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/project/tickets/${parentId}/products/count`,
@@ -1912,7 +1939,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectTicketsByParentIdScheduleentries(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ScheduleEntryReference> = {},
   ): Promise<Array<ScheduleEntryReference>> {
     return this.request({
       path: `/project/tickets/${parentId}/scheduleentries`,
@@ -1923,7 +1950,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectTicketsByParentIdScheduleentriesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/project/tickets/${parentId}/scheduleentries/count`,
@@ -1934,7 +1961,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectTicketsByParentIdTasks(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TicketTask> = {},
   ): Promise<Array<TicketTask>> {
     return this.request({
       path: `/project/tickets/${parentId}/tasks`,
@@ -1954,7 +1981,7 @@ export class ProjectAPI extends ManageBaseAPI {
   getProjectTicketsByParentIdTasksById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TicketTask> = {},
   ): Promise<TicketTask> {
     return this.request({
       path: `/project/tickets/${parentId}/tasks/${id}`,
@@ -1999,7 +2026,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectTicketsByParentIdTasksCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/project/tickets/${parentId}/tasks/count`,
@@ -2010,7 +2037,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectTicketsByParentIdTimeentries(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TimeEntryReference> = {},
   ): Promise<Array<TimeEntryReference>> {
     return this.request({
       path: `/project/tickets/${parentId}/timeentries`,
@@ -2021,7 +2048,7 @@ export class ProjectAPI extends ManageBaseAPI {
 
   getProjectTicketsByParentIdTimeentriesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/project/tickets/${parentId}/timeentries/count`,
@@ -2030,7 +2057,7 @@ export class ProjectAPI extends ManageBaseAPI {
     })
   }
 
-  getProjectTicketsCount(params: CommonParameters = {}): Promise<Count> {
+  getProjectTicketsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/project/tickets/count`,
       method: 'get',

--- a/src/Manage/SalesAPI.ts
+++ b/src/Manage/SalesAPI.ts
@@ -104,7 +104,7 @@ export type Usage = schemas['Usage']
  * @public
  */
 export class SalesAPI extends ManageBaseAPI {
-  getSalesActivities(params: CommonParameters = {}): Promise<Array<Activity>> {
+  getSalesActivities(params: CommonParameters<Activity> = {}): Promise<Array<Activity>> {
     return this.request({
       path: `/sales/activities`,
       method: 'get',
@@ -120,7 +120,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesActivitiesById(id: number, params: CommonParameters = {}): Promise<Activity> {
+  getSalesActivitiesById(id: number, params: CommonParameters<Activity> = {}): Promise<Activity> {
     return this.request({
       path: `/sales/activities/${id}`,
       method: 'get',
@@ -151,7 +151,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesActivitiesCount(params: CommonParameters = {}): Promise<Count> {
+  getSalesActivitiesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/sales/activities/count`,
       method: 'get',
@@ -159,7 +159,9 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesActivitiesStatuses(params: CommonParameters = {}): Promise<Array<ActivityStatus>> {
+  getSalesActivitiesStatuses(
+    params: CommonParameters<ActivityStatus> = {},
+  ): Promise<Array<ActivityStatus>> {
     return this.request({
       path: `/sales/activities/statuses`,
       method: 'get',
@@ -177,7 +179,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesActivitiesStatusesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ActivityStatus> = {},
   ): Promise<ActivityStatus> {
     return this.request({
       path: `/sales/activities/statuses/${id}`,
@@ -217,7 +219,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesActivitiesStatusesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ActivityStatusInfo> = {},
   ): Promise<ActivityStatusInfo> {
     return this.request({
       path: `/sales/activities/statuses/${id}/info`,
@@ -226,7 +228,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesActivitiesStatusesCount(params: CommonParameters = {}): Promise<Count> {
+  getSalesActivitiesStatusesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/sales/activities/statuses/count`,
       method: 'get',
@@ -235,7 +237,7 @@ export class SalesAPI extends ManageBaseAPI {
   }
 
   getSalesActivitiesStatusesInfo(
-    params: CommonParameters = {},
+    params: CommonParameters<ActivityStatusInfo> = {},
   ): Promise<Array<ActivityStatusInfo>> {
     return this.request({
       path: `/sales/activities/statuses/info`,
@@ -244,7 +246,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesActivitiesStatusesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getSalesActivitiesStatusesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/sales/activities/statuses/info/count`,
       method: 'get',
@@ -252,7 +254,9 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesActivitiesTypes(params: CommonParameters = {}): Promise<Array<ActivityType>> {
+  getSalesActivitiesTypes(
+    params: CommonParameters<ActivityType> = {},
+  ): Promise<Array<ActivityType>> {
     return this.request({
       path: `/sales/activities/types`,
       method: 'get',
@@ -268,7 +272,10 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesActivitiesTypesById(id: number, params: CommonParameters = {}): Promise<ActivityType> {
+  getSalesActivitiesTypesById(
+    id: number,
+    params: CommonParameters<ActivityType> = {},
+  ): Promise<ActivityType> {
     return this.request({
       path: `/sales/activities/types/${id}`,
       method: 'get',
@@ -304,7 +311,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesActivitiesTypesByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/sales/activities/types/${id}/usages`,
@@ -315,7 +322,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesActivitiesTypesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/sales/activities/types/${id}/usages/list`,
@@ -324,7 +331,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesActivitiesTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getSalesActivitiesTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/sales/activities/types/count`,
       method: 'get',
@@ -332,7 +339,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesCommissions(params: CommonParameters = {}): Promise<Array<Commission>> {
+  getSalesCommissions(params: CommonParameters<Commission> = {}): Promise<Array<Commission>> {
     return this.request({
       path: `/sales/commissions`,
       method: 'get',
@@ -348,7 +355,10 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesCommissionsById(id: number, params: CommonParameters = {}): Promise<Commission> {
+  getSalesCommissionsById(
+    id: number,
+    params: CommonParameters<Commission> = {},
+  ): Promise<Commission> {
     return this.request({
       path: `/sales/commissions/${id}`,
       method: 'get',
@@ -382,7 +392,10 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesCommissionsByIdUsages(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getSalesCommissionsByIdUsages(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/sales/commissions/${id}/usages`,
       method: 'get',
@@ -392,7 +405,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesCommissionsByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/sales/commissions/${id}/usages/list`,
@@ -401,7 +414,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesCommissionsCount(params: CommonParameters = {}): Promise<Count> {
+  getSalesCommissionsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/sales/commissions/count`,
       method: 'get',
@@ -409,7 +422,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesOpportunities(params: CommonParameters = {}): Promise<Array<Opportunity>> {
+  getSalesOpportunities(params: CommonParameters<Opportunity> = {}): Promise<Array<Opportunity>> {
     return this.request({
       path: `/sales/opportunities`,
       method: 'get',
@@ -425,7 +438,10 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesOpportunitiesById(id: number, params: CommonParameters = {}): Promise<Opportunity> {
+  getSalesOpportunitiesById(
+    id: number,
+    params: CommonParameters<Opportunity> = {},
+  ): Promise<Opportunity> {
     return this.request({
       path: `/sales/opportunities/${id}`,
       method: 'get',
@@ -505,7 +521,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOpportunitiesByParentIdContacts(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<OpportunityContact> = {},
   ): Promise<Array<OpportunityContact>> {
     return this.request({
       path: `/sales/opportunities/${parentId}/contacts`,
@@ -528,7 +544,7 @@ export class SalesAPI extends ManageBaseAPI {
   getSalesOpportunitiesByParentIdContactsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<OpportunityContact> = {},
   ): Promise<OpportunityContact> {
     return this.request({
       path: `/sales/opportunities/${parentId}/contacts/${id}`,
@@ -573,7 +589,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOpportunitiesByParentIdContactsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/sales/opportunities/${parentId}/contacts/count`,
@@ -584,7 +600,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOpportunitiesByParentIdForecast(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Forecast> = {},
   ): Promise<Array<Forecast>> {
     return this.request({
       path: `/sales/opportunities/${parentId}/forecast`,
@@ -633,7 +649,7 @@ export class SalesAPI extends ManageBaseAPI {
   getSalesOpportunitiesByParentIdForecastById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ForecastItem> = {},
   ): Promise<ForecastItem> {
     return this.request({
       path: `/sales/opportunities/${parentId}/forecast/${id}`,
@@ -700,7 +716,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOpportunitiesByParentIdForecastCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/sales/opportunities/${parentId}/forecast/count`,
@@ -711,7 +727,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOpportunitiesByParentIdNotes(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<OpportunityNote> = {},
   ): Promise<Array<OpportunityNote>> {
     return this.request({
       path: `/sales/opportunities/${parentId}/notes`,
@@ -734,7 +750,7 @@ export class SalesAPI extends ManageBaseAPI {
   getSalesOpportunitiesByParentIdNotesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<OpportunityNote> = {},
   ): Promise<OpportunityNote> {
     return this.request({
       path: `/sales/opportunities/${parentId}/notes/${id}`,
@@ -779,7 +795,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOpportunitiesByParentIdNotesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<OpportunityNote> = {},
   ): Promise<Array<OpportunityNote>> {
     return this.request({
       path: `/sales/opportunities/${parentId}/notes/count`,
@@ -790,7 +806,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOpportunitiesByParentIdTeam(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Team> = {},
   ): Promise<Array<Team>> {
     return this.request({
       path: `/sales/opportunities/${parentId}/team`,
@@ -810,7 +826,7 @@ export class SalesAPI extends ManageBaseAPI {
   getSalesOpportunitiesByParentIdTeamById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Team> = {},
   ): Promise<Team> {
     return this.request({
       path: `/sales/opportunities/${parentId}/team/${id}`,
@@ -851,7 +867,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOpportunitiesByParentIdTeamCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/sales/opportunities/${parentId}/team/count`,
@@ -862,7 +878,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOpportunitiesConversionsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<SalesConversion> = {},
   ): Promise<Array<SalesConversion>> {
     return this.request({
       path: `/sales/opportunities/conversions/${id}`,
@@ -871,7 +887,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesOpportunitiesCount(params: CommonParameters = {}): Promise<Count> {
+  getSalesOpportunitiesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/sales/opportunities/count`,
       method: 'get',
@@ -879,7 +895,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesOpportunitiesDefault(params: CommonParameters = {}): Promise<Opportunity> {
+  getSalesOpportunitiesDefault(params: CommonParameters<Opportunity> = {}): Promise<Opportunity> {
     return this.request({
       path: `/sales/opportunities/default`,
       method: 'get',
@@ -887,7 +903,9 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesOpportunitiesRatings(params: CommonParameters = {}): Promise<Array<OpportunityRating>> {
+  getSalesOpportunitiesRatings(
+    params: CommonParameters<OpportunityRating> = {},
+  ): Promise<Array<OpportunityRating>> {
     return this.request({
       path: `/sales/opportunities/ratings`,
       method: 'get',
@@ -905,7 +923,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOpportunitiesRatingsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<OpportunityRating> = {},
   ): Promise<OpportunityRating> {
     return this.request({
       path: `/sales/opportunities/ratings/${id}`,
@@ -945,7 +963,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOpportunitiesRatingsByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<OpportunityRatingInfo> = {},
   ): Promise<OpportunityRatingInfo> {
     return this.request({
       path: `/sales/opportunities/ratings/${id}/info`,
@@ -954,7 +972,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesOpportunitiesRatingsCount(params: CommonParameters = {}): Promise<Count> {
+  getSalesOpportunitiesRatingsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/sales/opportunities/ratings/count`,
       method: 'get',
@@ -963,7 +981,7 @@ export class SalesAPI extends ManageBaseAPI {
   }
 
   getSalesOpportunitiesRatingsInfo(
-    params: CommonParameters = {},
+    params: CommonParameters<OpportunityRatingInfo> = {},
   ): Promise<Array<OpportunityRatingInfo>> {
     return this.request({
       path: `/sales/opportunities/ratings/info`,
@@ -972,7 +990,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesOpportunitiesRatingsInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getSalesOpportunitiesRatingsInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/sales/opportunities/ratings/info/count`,
       method: 'get',
@@ -980,7 +998,9 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesOpportunitiesStatuses(params: CommonParameters = {}): Promise<Array<OpportunityStatus>> {
+  getSalesOpportunitiesStatuses(
+    params: CommonParameters<OpportunityStatus> = {},
+  ): Promise<Array<OpportunityStatus>> {
     return this.request({
       path: `/sales/opportunities/statuses`,
       method: 'get',
@@ -998,7 +1018,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOpportunitiesStatusesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<OpportunityStatus> = {},
   ): Promise<OpportunityStatus> {
     return this.request({
       path: `/sales/opportunities/statuses/${id}`,
@@ -1038,7 +1058,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOpportunitiesStatusesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<OpportunityStatusInfo> = {},
   ): Promise<OpportunityStatusInfo> {
     return this.request({
       path: `/sales/opportunities/statuses/${id}/info`,
@@ -1049,7 +1069,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOpportunitiesStatusesByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/sales/opportunities/statuses/${id}/usages`,
@@ -1060,7 +1080,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOpportunitiesStatusesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/sales/opportunities/statuses/${id}/usages/list`,
@@ -1069,7 +1089,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesOpportunitiesStatusesCount(params: CommonParameters = {}): Promise<Count> {
+  getSalesOpportunitiesStatusesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/sales/opportunities/statuses/count`,
       method: 'get',
@@ -1078,7 +1098,7 @@ export class SalesAPI extends ManageBaseAPI {
   }
 
   getSalesOpportunitiesStatusesInfo(
-    params: CommonParameters = {},
+    params: CommonParameters<OpportunityStatusInfo> = {},
   ): Promise<Array<OpportunityStatusInfo>> {
     return this.request({
       path: `/sales/opportunities/statuses/info`,
@@ -1087,7 +1107,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesOpportunitiesStatusesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getSalesOpportunitiesStatusesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/sales/opportunities/statuses/info/count`,
       method: 'get',
@@ -1095,7 +1115,9 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesOpportunitiesTypes(params: CommonParameters = {}): Promise<Array<OpportunityType>> {
+  getSalesOpportunitiesTypes(
+    params: CommonParameters<OpportunityType> = {},
+  ): Promise<Array<OpportunityType>> {
     return this.request({
       path: `/sales/opportunities/types`,
       method: 'get',
@@ -1113,7 +1135,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOpportunitiesTypesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<OpportunityType> = {},
   ): Promise<OpportunityType> {
     return this.request({
       path: `/sales/opportunities/types/${id}`,
@@ -1153,7 +1175,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOpportunitiesTypesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<OpportunityTypeInfo> = {},
   ): Promise<OpportunityTypeInfo> {
     return this.request({
       path: `/sales/opportunities/types/${id}/info`,
@@ -1164,7 +1186,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOpportunitiesTypesByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/sales/opportunities/types/${id}/usages`,
@@ -1175,7 +1197,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOpportunitiesTypesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/sales/opportunities/types/${id}/usages/list`,
@@ -1184,7 +1206,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesOpportunitiesTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getSalesOpportunitiesTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/sales/opportunities/types/count`,
       method: 'get',
@@ -1193,7 +1215,7 @@ export class SalesAPI extends ManageBaseAPI {
   }
 
   getSalesOpportunitiesTypesInfo(
-    params: CommonParameters = {},
+    params: CommonParameters<OpportunityTypeInfo> = {},
   ): Promise<Array<OpportunityTypeInfo>> {
     return this.request({
       path: `/sales/opportunities/types/info`,
@@ -1202,7 +1224,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesOpportunitiesTypesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getSalesOpportunitiesTypesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/sales/opportunities/types/info/count`,
       method: 'get',
@@ -1210,7 +1232,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesOrders(params: CommonParameters = {}): Promise<Array<Order>> {
+  getSalesOrders(params: CommonParameters<Order> = {}): Promise<Array<Order>> {
     return this.request({
       path: `/sales/orders`,
       method: 'get',
@@ -1226,7 +1248,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesOrdersById(id: number, params: CommonParameters = {}): Promise<Order> {
+  getSalesOrdersById(id: number, params: CommonParameters<Order> = {}): Promise<Order> {
     return this.request({
       path: `/sales/orders/${id}`,
       method: 'get',
@@ -1292,7 +1314,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOrdersByIdFinancialrecap(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<SalesOrderRecap> = {},
   ): Promise<Array<SalesOrderRecap>> {
     return this.request({
       path: `/sales/orders/${id}/financialrecap`,
@@ -1303,7 +1325,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOrdersByParentIdLineitems(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<SalesOrdersLineItem> = {},
   ): Promise<Array<SalesOrdersLineItem>> {
     return this.request({
       path: `/sales/orders/${parentId}/lineitems/`,
@@ -1326,7 +1348,7 @@ export class SalesAPI extends ManageBaseAPI {
   getSalesOrdersByParentIdLineitemsById(
     parentId: number,
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<SalesOrdersLineItem> = {},
   ): Promise<SalesOrdersLineItem> {
     return this.request({
       path: `/sales/orders/${parentId}/lineitems/${id}`,
@@ -1371,7 +1393,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOrdersByParentIdLineitemsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/sales/orders/${parentId}/lineitems/count`,
@@ -1382,7 +1404,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOrdersConversionsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<SalesConversion> = {},
   ): Promise<Array<SalesConversion>> {
     return this.request({
       path: `/sales/orders/conversions/${id}`,
@@ -1391,7 +1413,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesOrdersCount(params: CommonParameters = {}): Promise<Count> {
+  getSalesOrdersCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/sales/orders/count`,
       method: 'get',
@@ -1399,7 +1421,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesOrdersStatuses(params: CommonParameters = {}): Promise<Array<OrderStatus>> {
+  getSalesOrdersStatuses(params: CommonParameters<OrderStatus> = {}): Promise<Array<OrderStatus>> {
     return this.request({
       path: `/sales/orders/statuses`,
       method: 'get',
@@ -1415,7 +1437,10 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesOrdersStatusesById(id: number, params: CommonParameters = {}): Promise<OrderStatus> {
+  getSalesOrdersStatusesById(
+    id: number,
+    params: CommonParameters<OrderStatus> = {},
+  ): Promise<OrderStatus> {
     return this.request({
       path: `/sales/orders/statuses/${id}`,
       method: 'get',
@@ -1451,7 +1476,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOrdersStatusesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<OrderStatusInfo> = {},
   ): Promise<OrderStatusInfo> {
     return this.request({
       path: `/sales/orders/statuses/${id}/info`,
@@ -1462,7 +1487,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOrdersStatusesByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/sales/orders/statuses/${id}/usages`,
@@ -1473,7 +1498,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOrdersStatusesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/sales/orders/statuses/${id}/usages/list`,
@@ -1484,7 +1509,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOrdersStatusesByParentIdEmailtemplates(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<OrderStatusEmailTemplate> = {},
   ): Promise<Array<OrderStatusEmailTemplate>> {
     return this.request({
       path: `/sales/orders/statuses/${parentId}/emailtemplates/`,
@@ -1507,7 +1532,7 @@ export class SalesAPI extends ManageBaseAPI {
   getSalesOrdersStatusesByParentIdEmailtemplatesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<OrderStatusEmailTemplate> = {},
   ): Promise<OrderStatusEmailTemplate> {
     return this.request({
       path: `/sales/orders/statuses/${parentId}/emailtemplates/${id}`,
@@ -1552,7 +1577,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOrdersStatusesByParentIdEmailtemplatesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/sales/orders/statuses/${parentId}/emailtemplates/count`,
@@ -1563,7 +1588,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOrdersStatusesByParentIdNotifications(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<OrderStatusNotification> = {},
   ): Promise<Array<OrderStatusNotification>> {
     return this.request({
       path: `/sales/orders/statuses/${parentId}/notifications`,
@@ -1586,7 +1611,7 @@ export class SalesAPI extends ManageBaseAPI {
   getSalesOrdersStatusesByParentIdNotificationsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<OrderStatusNotification> = {},
   ): Promise<OrderStatusNotification> {
     return this.request({
       path: `/sales/orders/statuses/${parentId}/notifications/${id}`,
@@ -1631,7 +1656,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesOrdersStatusesByParentIdNotificationsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/sales/orders/statuses/${parentId}/notifications/count`,
@@ -1640,7 +1665,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesOrdersStatusesCount(params: CommonParameters = {}): Promise<Count> {
+  getSalesOrdersStatusesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/sales/orders/statuses/count`,
       method: 'get',
@@ -1648,7 +1673,9 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesOrdersStatusesInfo(params: CommonParameters = {}): Promise<Array<OrderStatusInfo>> {
+  getSalesOrdersStatusesInfo(
+    params: CommonParameters<OrderStatusInfo> = {},
+  ): Promise<Array<OrderStatusInfo>> {
     return this.request({
       path: `/sales/orders/statuses/info`,
       method: 'get',
@@ -1656,7 +1683,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesOrdersStatusesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getSalesOrdersStatusesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/sales/orders/statuses/info/count`,
       method: 'get',
@@ -1664,7 +1691,9 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesProbabilities(params: CommonParameters = {}): Promise<Array<SalesProbability>> {
+  getSalesProbabilities(
+    params: CommonParameters<SalesProbability> = {},
+  ): Promise<Array<SalesProbability>> {
     return this.request({
       path: `/sales/probabilities`,
       method: 'get',
@@ -1680,7 +1709,10 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesProbabilitiesById(id: number, params: CommonParameters = {}): Promise<SalesProbability> {
+  getSalesProbabilitiesById(
+    id: number,
+    params: CommonParameters<SalesProbability> = {},
+  ): Promise<SalesProbability> {
     return this.request({
       path: `/sales/probabilities/${id}`,
       method: 'get',
@@ -1716,7 +1748,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesProbabilitiesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<SalesProbabilityInfo> = {},
   ): Promise<SalesProbabilityInfo> {
     return this.request({
       path: `/sales/probabilities/${id}/info`,
@@ -1725,7 +1757,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesProbabilitiesCount(params: CommonParameters = {}): Promise<Count> {
+  getSalesProbabilitiesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/sales/probabilities/count`,
       method: 'get',
@@ -1733,7 +1765,9 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesProbabilitiesInfo(params: CommonParameters = {}): Promise<Array<SalesProbabilityInfo>> {
+  getSalesProbabilitiesInfo(
+    params: CommonParameters<SalesProbabilityInfo> = {},
+  ): Promise<Array<SalesProbabilityInfo>> {
     return this.request({
       path: `/sales/probabilities/info`,
       method: 'get',
@@ -1741,7 +1775,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesProbabilitiesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getSalesProbabilitiesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/sales/probabilities/info/count`,
       method: 'get',
@@ -1749,7 +1783,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesQuotas(params: CommonParameters = {}): Promise<Array<SalesQuota>> {
+  getSalesQuotas(params: CommonParameters<SalesQuota> = {}): Promise<Array<SalesQuota>> {
     return this.request({
       path: `/sales/quotas`,
       method: 'get',
@@ -1765,7 +1799,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesQuotasById(id: number, params: CommonParameters = {}): Promise<SalesQuota> {
+  getSalesQuotasById(id: number, params: CommonParameters<SalesQuota> = {}): Promise<SalesQuota> {
     return this.request({
       path: `/sales/quotas/${id}`,
       method: 'get',
@@ -1796,7 +1830,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesQuotasCount(params: CommonParameters = {}): Promise<Count> {
+  getSalesQuotasCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/sales/quotas/count`,
       method: 'get',
@@ -1804,7 +1838,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesRoles(params: CommonParameters = {}): Promise<Array<Role>> {
+  getSalesRoles(params: CommonParameters<Role> = {}): Promise<Array<Role>> {
     return this.request({
       path: `/sales/roles`,
       method: 'get',
@@ -1820,7 +1854,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesRolesById(id: number, params: CommonParameters = {}): Promise<Role> {
+  getSalesRolesById(id: number, params: CommonParameters<Role> = {}): Promise<Role> {
     return this.request({
       path: `/sales/roles/${id}`,
       method: 'get',
@@ -1851,7 +1885,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesRolesCount(params: CommonParameters = {}): Promise<Count> {
+  getSalesRolesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/sales/roles/count`,
       method: 'get',
@@ -1859,7 +1893,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesSalesTeams(params: CommonParameters = {}): Promise<Array<SalesTeam>> {
+  getSalesSalesTeams(params: CommonParameters<SalesTeam> = {}): Promise<Array<SalesTeam>> {
     return this.request({
       path: `/sales/salesTeams`,
       method: 'get',
@@ -1875,7 +1909,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesSalesTeamsById(id: number, params: CommonParameters = {}): Promise<SalesTeam> {
+  getSalesSalesTeamsById(id: number, params: CommonParameters<SalesTeam> = {}): Promise<SalesTeam> {
     return this.request({
       path: `/sales/salesTeams/${id}`,
       method: 'get',
@@ -1908,7 +1942,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesSalesTeamsByParentIdMembers(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<SalesTeamMember> = {},
   ): Promise<Array<SalesTeamMember>> {
     return this.request({
       path: `/sales/salesTeams/${parentId}/members`,
@@ -1931,7 +1965,7 @@ export class SalesAPI extends ManageBaseAPI {
   getSalesSalesTeamsByParentIdMembersById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<SalesTeamMember> = {},
   ): Promise<SalesTeamMember> {
     return this.request({
       path: `/sales/salesTeams/${parentId}/members/${id}`,
@@ -1976,7 +2010,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesSalesTeamsByParentIdMembersCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/sales/salesTeams/${parentId}/members/count`,
@@ -1985,7 +2019,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesSalesTeamsCount(params: CommonParameters = {}): Promise<Count> {
+  getSalesSalesTeamsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/sales/salesTeams/count`,
       method: 'get',
@@ -1995,7 +2029,7 @@ export class SalesAPI extends ManageBaseAPI {
 
   getSalesScheduleHolidaylistsByParentIdHolidaysInfoCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/sales/schedule/holidaylists/${parentId}/holidays/info/count`,
@@ -2004,7 +2038,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesScheduleHolidaylistsInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getSalesScheduleHolidaylistsInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/sales/schedule/holidaylists/info/count`,
       method: 'get',
@@ -2012,7 +2046,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesServicePriorityInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getSalesServicePriorityInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/sales/service/priority/info/count`,
       method: 'get',
@@ -2020,7 +2054,9 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesStages(params: CommonParameters = {}): Promise<Array<OpportunityStage>> {
+  getSalesStages(
+    params: CommonParameters<OpportunityStage> = {},
+  ): Promise<Array<OpportunityStage>> {
     return this.request({
       path: `/sales/stages`,
       method: 'get',
@@ -2036,7 +2072,10 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesStagesById(id: number, params: CommonParameters = {}): Promise<OpportunityStage> {
+  getSalesStagesById(
+    id: number,
+    params: CommonParameters<OpportunityStage> = {},
+  ): Promise<OpportunityStage> {
     return this.request({
       path: `/sales/stages/${id}`,
       method: 'get',
@@ -2070,7 +2109,10 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesStagesByIdInfo(id: number, params: CommonParameters = {}): Promise<OpportunityStageInfo> {
+  getSalesStagesByIdInfo(
+    id: number,
+    params: CommonParameters<OpportunityStageInfo> = {},
+  ): Promise<OpportunityStageInfo> {
     return this.request({
       path: `/sales/stages/${id}/info`,
       method: 'get',
@@ -2078,7 +2120,10 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesStagesByIdUsages(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getSalesStagesByIdUsages(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/sales/stages/${id}/usages`,
       method: 'get',
@@ -2086,7 +2131,10 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesStagesByIdUsagesList(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getSalesStagesByIdUsagesList(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/sales/stages/${id}/usages/list`,
       method: 'get',
@@ -2094,7 +2142,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesStagesCount(params: CommonParameters = {}): Promise<Count> {
+  getSalesStagesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/sales/stages/count`,
       method: 'get',
@@ -2102,7 +2150,9 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesStagesInfo(params: CommonParameters = {}): Promise<Array<OpportunityStageInfo>> {
+  getSalesStagesInfo(
+    params: CommonParameters<OpportunityStageInfo> = {},
+  ): Promise<Array<OpportunityStageInfo>> {
     return this.request({
       path: `/sales/stages/info`,
       method: 'get',
@@ -2110,7 +2160,7 @@ export class SalesAPI extends ManageBaseAPI {
     })
   }
 
-  getSalesStagesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getSalesStagesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/sales/stages/info/count`,
       method: 'get',

--- a/src/Manage/ScheduleAPI.ts
+++ b/src/Manage/ScheduleAPI.ts
@@ -48,7 +48,7 @@ export type Usage = schemas['Usage']
  * @public
  */
 export class ScheduleAPI extends ManageBaseAPI {
-  getScheduleCalendars(params: CommonParameters = {}): Promise<Array<Calendar>> {
+  getScheduleCalendars(params: CommonParameters<Calendar> = {}): Promise<Array<Calendar>> {
     return this.request({
       path: `/schedule/calendars`,
       method: 'get',
@@ -64,7 +64,7 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleCalendarsById(id: number, params: CommonParameters = {}): Promise<Calendar> {
+  getScheduleCalendarsById(id: number, params: CommonParameters<Calendar> = {}): Promise<Calendar> {
     return this.request({
       path: `/schedule/calendars/${id}`,
       method: 'get',
@@ -105,7 +105,10 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleCalendarsByIdInfo(id: number, params: CommonParameters = {}): Promise<CalendarInfo> {
+  getScheduleCalendarsByIdInfo(
+    id: number,
+    params: CommonParameters<CalendarInfo> = {},
+  ): Promise<CalendarInfo> {
     return this.request({
       path: `/schedule/calendars/${id}/info`,
       method: 'get',
@@ -113,7 +116,10 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleCalendarsByIdUsages(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getScheduleCalendarsByIdUsages(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/schedule/calendars/${id}/usages`,
       method: 'get',
@@ -123,7 +129,7 @@ export class ScheduleAPI extends ManageBaseAPI {
 
   getScheduleCalendarsByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/schedule/calendars/${id}/usages/list`,
@@ -132,7 +138,7 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleCalendarsCount(params: CommonParameters = {}): Promise<Calendar> {
+  getScheduleCalendarsCount(params: CommonParameters<Calendar> = {}): Promise<Calendar> {
     return this.request({
       path: `/schedule/calendars/count`,
       method: 'get',
@@ -140,7 +146,9 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleCalendarsInfo(params: CommonParameters = {}): Promise<Array<CalendarInfo>> {
+  getScheduleCalendarsInfo(
+    params: CommonParameters<CalendarInfo> = {},
+  ): Promise<Array<CalendarInfo>> {
     return this.request({
       path: `/schedule/calendars/info`,
       method: 'get',
@@ -148,7 +156,9 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleCalendarsInfoCount(params: CommonParameters = {}): Promise<CalendarInfo> {
+  getScheduleCalendarsInfoCount(
+    params: CommonParameters<CalendarInfo> = {},
+  ): Promise<CalendarInfo> {
     return this.request({
       path: `/schedule/calendars/info/count`,
       method: 'get',
@@ -156,7 +166,7 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleColors(params: CommonParameters = {}): Promise<Array<ScheduleColor>> {
+  getScheduleColors(params: CommonParameters<ScheduleColor> = {}): Promise<Array<ScheduleColor>> {
     return this.request({
       path: `/schedule/colors`,
       method: 'get',
@@ -164,7 +174,10 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleColorsById(id: number, params: CommonParameters = {}): Promise<ScheduleColor> {
+  getScheduleColorsById(
+    id: number,
+    params: CommonParameters<ScheduleColor> = {},
+  ): Promise<ScheduleColor> {
     return this.request({
       path: `/schedule/colors/${id}`,
       method: 'get',
@@ -198,7 +211,7 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleColorsCount(params: CommonParameters = {}): Promise<Count> {
+  getScheduleColorsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/schedule/colors/count`,
       method: 'get',
@@ -213,7 +226,9 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleDetails(params: CommonParameters = {}): Promise<Array<ScheduleEntryDetail>> {
+  getScheduleDetails(
+    params: CommonParameters<ScheduleEntryDetail> = {},
+  ): Promise<Array<ScheduleEntryDetail>> {
     return this.request({
       path: `/schedule/details`,
       method: 'get',
@@ -221,7 +236,10 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleDetailsById(id: number, params: CommonParameters = {}): Promise<ScheduleEntryDetail> {
+  getScheduleDetailsById(
+    id: number,
+    params: CommonParameters<ScheduleEntryDetail> = {},
+  ): Promise<ScheduleEntryDetail> {
     return this.request({
       path: `/schedule/details/${id}`,
       method: 'get',
@@ -229,7 +247,7 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleDetailsCount(params: CommonParameters = {}): Promise<Count> {
+  getScheduleDetailsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/schedule/details/count`,
       method: 'get',
@@ -237,7 +255,7 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleEntries(params: CommonParameters = {}): Promise<Array<ScheduleEntry>> {
+  getScheduleEntries(params: CommonParameters<ScheduleEntry> = {}): Promise<Array<ScheduleEntry>> {
     return this.request({
       path: `/schedule/entries`,
       method: 'get',
@@ -253,7 +271,10 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleEntriesById(id: number, params: CommonParameters = {}): Promise<ScheduleEntry> {
+  getScheduleEntriesById(
+    id: number,
+    params: CommonParameters<ScheduleEntry> = {},
+  ): Promise<ScheduleEntry> {
     return this.request({
       path: `/schedule/entries/${id}`,
       method: 'get',
@@ -299,7 +320,7 @@ export class ScheduleAPI extends ManageBaseAPI {
 
   getScheduleEntriesByParentIdDetails(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ScheduleDetail> = {},
   ): Promise<Array<ScheduleDetail>> {
     return this.request({
       path: `/schedule/entries/${parentId}/details`,
@@ -311,7 +332,7 @@ export class ScheduleAPI extends ManageBaseAPI {
   getScheduleEntriesByParentIdDetailsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ScheduleDetail> = {},
   ): Promise<ScheduleDetail> {
     return this.request({
       path: `/schedule/entries/${parentId}/details/${id}`,
@@ -322,7 +343,7 @@ export class ScheduleAPI extends ManageBaseAPI {
 
   getScheduleEntriesByParentIdDetailsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/schedule/entries/${parentId}/details/count`,
@@ -331,7 +352,7 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleEntriesCount(params: CommonParameters = {}): Promise<Count> {
+  getScheduleEntriesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/schedule/entries/count`,
       method: 'get',
@@ -339,7 +360,7 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleHolidayLists(params: CommonParameters = {}): Promise<Array<HolidayList>> {
+  getScheduleHolidayLists(params: CommonParameters<HolidayList> = {}): Promise<Array<HolidayList>> {
     return this.request({
       path: `/schedule/holidayLists`,
       method: 'get',
@@ -355,7 +376,10 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleHolidayListsById(id: number, params: CommonParameters = {}): Promise<HolidayList> {
+  getScheduleHolidayListsById(
+    id: number,
+    params: CommonParameters<HolidayList> = {},
+  ): Promise<HolidayList> {
     return this.request({
       path: `/schedule/holidayLists/${id}`,
       method: 'get',
@@ -391,7 +415,7 @@ export class ScheduleAPI extends ManageBaseAPI {
 
   getScheduleHolidaylistsByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<HolidayListInfo> = {},
   ): Promise<HolidayListInfo> {
     return this.request({
       path: `/schedule/holidaylists/${id}/info`,
@@ -402,7 +426,7 @@ export class ScheduleAPI extends ManageBaseAPI {
 
   getScheduleHolidayListsByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/schedule/holidayLists/${id}/usages`,
@@ -413,7 +437,7 @@ export class ScheduleAPI extends ManageBaseAPI {
 
   getScheduleHolidayListsByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/schedule/holidayLists/${id}/usages/list`,
@@ -424,7 +448,7 @@ export class ScheduleAPI extends ManageBaseAPI {
 
   getScheduleHolidayListsByParentIdHolidays(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Holiday> = {},
   ): Promise<Array<Holiday>> {
     return this.request({
       path: `/schedule/holidayLists/${parentId}/holidays`,
@@ -444,7 +468,7 @@ export class ScheduleAPI extends ManageBaseAPI {
   getScheduleHolidayListsByParentIdHolidaysById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Holiday> = {},
   ): Promise<Holiday> {
     return this.request({
       path: `/schedule/holidayLists/${parentId}/holidays/${id}`,
@@ -490,7 +514,7 @@ export class ScheduleAPI extends ManageBaseAPI {
   getScheduleHolidaylistsByParentIdHolidaysByIdInfo(
     parentId: number,
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<HolidayInfo> = {},
   ): Promise<HolidayInfo> {
     return this.request({
       path: `/schedule/holidaylists/${parentId}/holidays/${id}/info`,
@@ -501,7 +525,7 @@ export class ScheduleAPI extends ManageBaseAPI {
 
   getScheduleHolidayListsByParentIdHolidaysCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/schedule/holidayLists/${parentId}/holidays/count`,
@@ -512,7 +536,7 @@ export class ScheduleAPI extends ManageBaseAPI {
 
   getScheduleHolidaylistsByParentIdHolidaysInfo(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<HolidayInfo> = {},
   ): Promise<Array<HolidayInfo>> {
     return this.request({
       path: `/schedule/holidaylists/${parentId}/holidays/info`,
@@ -529,7 +553,7 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleHolidayListsCount(params: CommonParameters = {}): Promise<Count> {
+  getScheduleHolidayListsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/schedule/holidayLists/count`,
       method: 'get',
@@ -537,7 +561,9 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleHolidaylistsInfo(params: CommonParameters = {}): Promise<Array<HolidayListInfo>> {
+  getScheduleHolidaylistsInfo(
+    params: CommonParameters<HolidayListInfo> = {},
+  ): Promise<Array<HolidayListInfo>> {
     return this.request({
       path: `/schedule/holidaylists/info`,
       method: 'get',
@@ -545,7 +571,9 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getSchedulePortalcalendars(params: CommonParameters = {}): Promise<Array<PortalCalendar>> {
+  getSchedulePortalcalendars(
+    params: CommonParameters<PortalCalendar> = {},
+  ): Promise<Array<PortalCalendar>> {
     return this.request({
       path: `/schedule/portalcalendars`,
       method: 'get',
@@ -555,7 +583,7 @@ export class ScheduleAPI extends ManageBaseAPI {
 
   getSchedulePortalcalendarsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<PortalCalendar> = {},
   ): Promise<PortalCalendar> {
     return this.request({
       path: `/schedule/portalcalendars/${id}`,
@@ -586,7 +614,7 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getSchedulePortalcalendarsCount(params: CommonParameters = {}): Promise<Count> {
+  getSchedulePortalcalendarsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/schedule/portalcalendars/count`,
       method: 'get',
@@ -594,7 +622,9 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleReminderTimes(params: CommonParameters = {}): Promise<Array<ScheduleReminderTime>> {
+  getScheduleReminderTimes(
+    params: CommonParameters<ScheduleReminderTime> = {},
+  ): Promise<Array<ScheduleReminderTime>> {
     return this.request({
       path: `/schedule/reminderTimes`,
       method: 'get',
@@ -604,7 +634,7 @@ export class ScheduleAPI extends ManageBaseAPI {
 
   getScheduleReminderTimesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ScheduleReminderTime> = {},
   ): Promise<ScheduleReminderTime> {
     return this.request({
       path: `/schedule/reminderTimes/${id}`,
@@ -635,7 +665,7 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleReminderTimesCount(params: CommonParameters = {}): Promise<Count> {
+  getScheduleReminderTimesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/schedule/reminderTimes/count`,
       method: 'get',
@@ -643,7 +673,9 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleStatuses(params: CommonParameters = {}): Promise<Array<ScheduleStatus>> {
+  getScheduleStatuses(
+    params: CommonParameters<ScheduleStatus> = {},
+  ): Promise<Array<ScheduleStatus>> {
     return this.request({
       path: `/schedule/statuses`,
       method: 'get',
@@ -659,7 +691,10 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleStatusesById(id: number, params: CommonParameters = {}): Promise<ScheduleStatus> {
+  getScheduleStatusesById(
+    id: number,
+    params: CommonParameters<ScheduleStatus> = {},
+  ): Promise<ScheduleStatus> {
     return this.request({
       path: `/schedule/statuses/${id}`,
       method: 'get',
@@ -695,7 +730,7 @@ export class ScheduleAPI extends ManageBaseAPI {
 
   getScheduleStatusesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ScheduleStatusInfo> = {},
   ): Promise<ScheduleStatusInfo> {
     return this.request({
       path: `/schedule/statuses/${id}/info`,
@@ -704,7 +739,7 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleStatusesCount(params: CommonParameters = {}): Promise<Count> {
+  getScheduleStatusesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/schedule/statuses/count`,
       method: 'get',
@@ -712,7 +747,9 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleStatusesInfo(params: CommonParameters = {}): Promise<Array<ScheduleStatusInfo>> {
+  getScheduleStatusesInfo(
+    params: CommonParameters<ScheduleStatusInfo> = {},
+  ): Promise<Array<ScheduleStatusInfo>> {
     return this.request({
       path: `/schedule/statuses/info`,
       method: 'get',
@@ -720,7 +757,7 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleStatusesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getScheduleStatusesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/schedule/statuses/info/count`,
       method: 'get',
@@ -728,7 +765,7 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleTypes(params: CommonParameters = {}): Promise<Array<ScheduleType>> {
+  getScheduleTypes(params: CommonParameters<ScheduleType> = {}): Promise<Array<ScheduleType>> {
     return this.request({
       path: `/schedule/types`,
       method: 'get',
@@ -744,7 +781,10 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleTypesById(id: number, params: CommonParameters = {}): Promise<ScheduleType> {
+  getScheduleTypesById(
+    id: number,
+    params: CommonParameters<ScheduleType> = {},
+  ): Promise<ScheduleType> {
     return this.request({
       path: `/schedule/types/${id}`,
       method: 'get',
@@ -778,7 +818,10 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleTypesByIdInfo(id: number, params: CommonParameters = {}): Promise<ScheduleTypeInfo> {
+  getScheduleTypesByIdInfo(
+    id: number,
+    params: CommonParameters<ScheduleTypeInfo> = {},
+  ): Promise<ScheduleTypeInfo> {
     return this.request({
       path: `/schedule/types/${id}/info`,
       method: 'get',
@@ -786,7 +829,10 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleTypesByIdUsages(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getScheduleTypesByIdUsages(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/schedule/types/${id}/usages`,
       method: 'get',
@@ -794,7 +840,10 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleTypesByIdUsagesList(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getScheduleTypesByIdUsagesList(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/schedule/types/${id}/usages/list`,
       method: 'get',
@@ -802,7 +851,7 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getScheduleTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/schedule/types/count`,
       method: 'get',
@@ -810,7 +859,9 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleTypesInfo(params: CommonParameters = {}): Promise<Array<ScheduleTypeInfo>> {
+  getScheduleTypesInfo(
+    params: CommonParameters<ScheduleTypeInfo> = {},
+  ): Promise<Array<ScheduleTypeInfo>> {
     return this.request({
       path: `/schedule/types/info`,
       method: 'get',
@@ -818,7 +869,7 @@ export class ScheduleAPI extends ManageBaseAPI {
     })
   }
 
-  getScheduleTypesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getScheduleTypesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/schedule/types/info/count`,
       method: 'get',

--- a/src/Manage/ServiceAPI.ts
+++ b/src/Manage/ServiceAPI.ts
@@ -160,7 +160,7 @@ export type Usage = schemas['Usage']
  * @public
  */
 export class ServiceAPI extends ManageBaseAPI {
-  getServiceBoards(params: CommonParameters = {}): Promise<Array<Board>> {
+  getServiceBoards(params: CommonParameters<Board> = {}): Promise<Array<Board>> {
     return this.request({
       path: `/service/boards`,
       method: 'get',
@@ -179,7 +179,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByGrandparentIdItemsByParentIdAssociations(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardItemAssociation> = {},
   ): Promise<Array<BoardItemAssociation>> {
     return this.request({
       path: `/service/boards/${grandparentId}/items/${parentId}/associations`,
@@ -192,7 +192,7 @@ export class ServiceAPI extends ManageBaseAPI {
     id: number,
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardItemAssociation> = {},
   ): Promise<BoardItemAssociation> {
     return this.request({
       path: `/service/boards/${grandparentId}/items/${parentId}/associations/${id}`,
@@ -230,7 +230,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByGrandparentIdItemsByParentIdAssociationsCount(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/boards/${grandparentId}/items/${parentId}/associations/count`,
@@ -242,7 +242,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByGrandparentIdStatusesByParentIdNotifications(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardStatusNotification> = {},
   ): Promise<Array<BoardStatusNotification>> {
     return this.request({
       path: `/service/boards/${grandparentId}/statuses/${parentId}/notifications`,
@@ -267,7 +267,7 @@ export class ServiceAPI extends ManageBaseAPI {
     id: number,
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardStatusNotification> = {},
   ): Promise<BoardStatusNotification> {
     return this.request({
       path: `/service/boards/${grandparentId}/statuses/${parentId}/notifications/${id}`,
@@ -316,7 +316,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByGrandparentIdStatusesByParentIdNotificationsCount(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/boards/${grandparentId}/statuses/${parentId}/notifications/count`,
@@ -325,7 +325,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceBoardsById(id: number, params: CommonParameters = {}): Promise<Board> {
+  getServiceBoardsById(id: number, params: CommonParameters<Board> = {}): Promise<Board> {
     return this.request({
       path: `/service/boards/${id}`,
       method: 'get',
@@ -356,7 +356,10 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceBoardsByIdUsages(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getServiceBoardsByIdUsages(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/boards/${id}/usages`,
       method: 'get',
@@ -364,7 +367,10 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceBoardsByIdUsagesList(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getServiceBoardsByIdUsagesList(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/boards/${id}/usages/list`,
       method: 'get',
@@ -374,7 +380,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdAutoAssignResources(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardAutoAssignResource> = {},
   ): Promise<Array<BoardAutoAssignResource>> {
     return this.request({
       path: `/service/boards/${parentId}/autoAssignResources`,
@@ -397,7 +403,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByParentIdAutoAssignResourcesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardAutoAssignResource> = {},
   ): Promise<BoardAutoAssignResource> {
     return this.request({
       path: `/service/boards/${parentId}/autoAssignResources/${id}`,
@@ -442,7 +448,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdAutoAssignResourcesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/boards/${parentId}/autoAssignResources/count`,
@@ -453,7 +459,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdAutoTemplates(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardAutoTemplate> = {},
   ): Promise<Array<BoardAutoTemplate>> {
     return this.request({
       path: `/service/boards/${parentId}/autoTemplates`,
@@ -476,7 +482,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByParentIdAutoTemplatesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardAutoTemplate> = {},
   ): Promise<BoardAutoTemplate> {
     return this.request({
       path: `/service/boards/${parentId}/autoTemplates/${id}`,
@@ -521,7 +527,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdAutoTemplatesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/boards/${parentId}/autoTemplates/count`,
@@ -532,7 +538,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdExcludedMembers(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardExcludedMember> = {},
   ): Promise<Array<BoardExcludedMember>> {
     return this.request({
       path: `/service/boards/${parentId}/excludedMembers`,
@@ -555,7 +561,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByParentIdExcludedMembersById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardExcludedMember> = {},
   ): Promise<BoardExcludedMember> {
     return this.request({
       path: `/service/boards/${parentId}/excludedMembers/${id}`,
@@ -576,7 +582,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdExcludedMembersCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/boards/${parentId}/excludedMembers/count`,
@@ -587,7 +593,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdItems(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardItem> = {},
   ): Promise<Array<BoardItem>> {
     return this.request({
       path: `/service/boards/${parentId}/items`,
@@ -607,7 +613,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByParentIdItemsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardItem> = {},
   ): Promise<BoardItem> {
     return this.request({
       path: `/service/boards/${parentId}/items/${id}`,
@@ -650,7 +656,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByParentIdItemsByIdUsages(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/boards/${parentId}/items/${id}/usages`,
@@ -662,7 +668,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByParentIdItemsByIdUsagesList(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/boards/${parentId}/items/${id}/usages/list`,
@@ -673,7 +679,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdItemsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/boards/${parentId}/items/count`,
@@ -684,7 +690,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdNotifications(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardNotification> = {},
   ): Promise<Array<BoardNotification>> {
     return this.request({
       path: `/service/boards/${parentId}/notifications`,
@@ -707,7 +713,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByParentIdNotificationsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardNotification> = {},
   ): Promise<BoardNotification> {
     return this.request({
       path: `/service/boards/${parentId}/notifications/${id}`,
@@ -752,7 +758,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdNotificationsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/boards/${parentId}/notifications/count`,
@@ -763,7 +769,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdSkillMappings(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardSkillMapping> = {},
   ): Promise<Array<BoardSkillMapping>> {
     return this.request({
       path: `/service/boards/${parentId}/skillMappings/`,
@@ -786,7 +792,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByParentIdSkillMappingsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardSkillMapping> = {},
   ): Promise<BoardSkillMapping> {
     return this.request({
       path: `/service/boards/${parentId}/skillMappings/${id}`,
@@ -831,7 +837,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdSkillMappingsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/boards/${parentId}/skillMappings/count`,
@@ -842,7 +848,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdStatuses(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardStatus> = {},
   ): Promise<Array<BoardStatus>> {
     return this.request({
       path: `/service/boards/${parentId}/statuses`,
@@ -865,7 +871,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByParentIdStatusesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardStatus> = {},
   ): Promise<BoardStatus> {
     return this.request({
       path: `/service/boards/${parentId}/statuses/${id}`,
@@ -911,7 +917,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByParentIdStatusesByIdInfo(
     parentId: number,
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardStatusInfo> = {},
   ): Promise<BoardStatusInfo> {
     return this.request({
       path: `/service/boards/${parentId}/statuses/${id}/info`,
@@ -923,7 +929,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByParentIdStatusesByIdUsages(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/boards/${parentId}/statuses/${id}/usages`,
@@ -935,7 +941,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByParentIdStatusesByIdUsagesList(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/boards/${parentId}/statuses/${id}/usages/list`,
@@ -946,7 +952,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdStatusesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/boards/${parentId}/statuses/count`,
@@ -957,7 +963,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdStatusesInfo(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardStatusInfo> = {},
   ): Promise<Array<BoardStatusInfo>> {
     return this.request({
       path: `/service/boards/${parentId}/statuses/info`,
@@ -968,7 +974,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdStatusesInfoCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/boards/${parentId}/statuses/info/count`,
@@ -979,7 +985,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdSubtypes(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardSubType> = {},
   ): Promise<Array<BoardSubType>> {
     return this.request({
       path: `/service/boards/${parentId}/subtypes`,
@@ -1002,7 +1008,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByParentIdSubtypesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardSubType> = {},
   ): Promise<BoardSubType> {
     return this.request({
       path: `/service/boards/${parentId}/subtypes/${id}`,
@@ -1048,7 +1054,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByParentIdSubtypesByIdInfo(
     parentId: number,
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardSubTypeInfo> = {},
   ): Promise<BoardSubTypeInfo> {
     return this.request({
       path: `/service/boards/${parentId}/subtypes/${id}/info`,
@@ -1060,7 +1066,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByParentIdSubtypesByIdUsages(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/boards/${parentId}/subtypes/${id}/usages`,
@@ -1072,7 +1078,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByParentIdSubtypesByIdUsagesList(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/boards/${parentId}/subtypes/${id}/usages/list`,
@@ -1083,7 +1089,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdSubtypesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/boards/${parentId}/subtypes/count`,
@@ -1094,7 +1100,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdSubtypesInfo(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardSubTypeInfo> = {},
   ): Promise<Array<BoardSubTypeInfo>> {
     return this.request({
       path: `/service/boards/${parentId}/subtypes/info`,
@@ -1105,7 +1111,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdSubtypesInfoCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/boards/${parentId}/subtypes/info/count`,
@@ -1116,7 +1122,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdTeams(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardTeam> = {},
   ): Promise<Array<BoardTeam>> {
     return this.request({
       path: `/service/boards/${parentId}/teams`,
@@ -1136,7 +1142,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByParentIdTeamsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardTeam> = {},
   ): Promise<BoardTeam> {
     return this.request({
       path: `/service/boards/${parentId}/teams/${id}`,
@@ -1179,7 +1185,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByParentIdTeamsByIdInfo(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardTeamInfo> = {},
   ): Promise<BoardTeamInfo> {
     return this.request({
       path: `/service/boards/${parentId}/teams/${id}/info`,
@@ -1191,7 +1197,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByParentIdTeamsByIdUsagesList(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/boards/${parentId}/teams/${id}/usages/list`,
@@ -1202,7 +1208,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdTeamsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/boards/${parentId}/teams/count`,
@@ -1213,7 +1219,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdTeamsInfo(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardTeamInfo> = {},
   ): Promise<Array<BoardTeamInfo>> {
     return this.request({
       path: `/service/boards/${parentId}/teams/info`,
@@ -1224,7 +1230,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdTeamsInfoCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/boards/${parentId}/teams/info/count`,
@@ -1235,7 +1241,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdTypes(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardType> = {},
   ): Promise<Array<BoardType>> {
     return this.request({
       path: `/service/boards/${parentId}/types`,
@@ -1255,7 +1261,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByParentIdTypesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardType> = {},
   ): Promise<BoardType> {
     return this.request({
       path: `/service/boards/${parentId}/types/${id}`,
@@ -1298,7 +1304,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByParentIdTypesByIdUsages(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/boards/${parentId}/types/${id}/usages`,
@@ -1310,7 +1316,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByParentIdTypesByIdUsagesList(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/boards/${parentId}/types/${id}/usages/list`,
@@ -1321,7 +1327,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdTypesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/boards/${parentId}/types/count`,
@@ -1332,7 +1338,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdTypeSubTypeItemAssociations(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardTypeSubTypeItemAssociation> = {},
   ): Promise<Array<BoardTypeSubTypeItemAssociation>> {
     return this.request({
       path: `/service/boards/${parentId}/typeSubTypeItemAssociations`,
@@ -1344,7 +1350,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceBoardsByParentIdTypeSubTypeItemAssociationsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<BoardTypeSubTypeItemAssociation> = {},
   ): Promise<BoardTypeSubTypeItemAssociation> {
     return this.request({
       path: `/service/boards/${parentId}/typeSubTypeItemAssociations/${id}`,
@@ -1355,7 +1361,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceBoardsByParentIdTypeSubTypeItemAssociationsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/boards/${parentId}/typeSubTypeItemAssociations/count`,
@@ -1372,7 +1378,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceBoardsCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceBoardsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/boards/count`,
       method: 'get',
@@ -1380,7 +1386,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceCodes(params: CommonParameters = {}): Promise<Array<Code>> {
+  getServiceCodes(params: CommonParameters<Code> = {}): Promise<Array<Code>> {
     return this.request({
       path: `/service/codes`,
       method: 'get',
@@ -1396,7 +1402,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceCodesById(id: number, params: CommonParameters = {}): Promise<Code> {
+  getServiceCodesById(id: number, params: CommonParameters<Code> = {}): Promise<Code> {
     return this.request({
       path: `/service/codes/${id}`,
       method: 'get',
@@ -1427,7 +1433,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceCodesCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceCodesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/codes/count`,
       method: 'get',
@@ -1435,7 +1441,9 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceEmailTemplates(params: CommonParameters = {}): Promise<Array<ServiceEmailTemplate>> {
+  getServiceEmailTemplates(
+    params: CommonParameters<ServiceEmailTemplate> = {},
+  ): Promise<Array<ServiceEmailTemplate>> {
     return this.request({
       path: `/service/emailTemplates`,
       method: 'get',
@@ -1455,7 +1463,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceEmailTemplatesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ServiceEmailTemplate> = {},
   ): Promise<ServiceEmailTemplate> {
     return this.request({
       path: `/service/emailTemplates/${id}`,
@@ -1495,7 +1503,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceEmailTemplatesByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/emailTemplates/${id}/usages`,
@@ -1506,7 +1514,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceEmailTemplatesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/emailTemplates/${id}/usages/list`,
@@ -1515,7 +1523,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceEmailTemplatesCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceEmailTemplatesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/emailTemplates/count`,
       method: 'get',
@@ -1523,7 +1531,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceImpacts(params: CommonParameters = {}): Promise<Array<Impact>> {
+  getServiceImpacts(params: CommonParameters<Impact> = {}): Promise<Array<Impact>> {
     return this.request({
       path: `/service/impacts`,
       method: 'get',
@@ -1531,7 +1539,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceImpactsById(id: number, params: CommonParameters = {}): Promise<Impact> {
+  getServiceImpactsById(id: number, params: CommonParameters<Impact> = {}): Promise<Impact> {
     return this.request({
       path: `/service/impacts/${id}`,
       method: 'get',
@@ -1555,7 +1563,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceImpactsCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceImpactsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/impacts/count`,
       method: 'get',
@@ -1563,7 +1571,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceInfoBoards(params: CommonParameters = {}): Promise<Array<BoardInfo>> {
+  getServiceInfoBoards(params: CommonParameters<BoardInfo> = {}): Promise<Array<BoardInfo>> {
     return this.request({
       path: `/service/info/boards`,
       method: 'get',
@@ -1571,7 +1579,10 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceInfoBoardsById(id: number, params: CommonParameters = {}): Promise<BoardInfo> {
+  getServiceInfoBoardsById(
+    id: number,
+    params: CommonParameters<BoardInfo> = {},
+  ): Promise<BoardInfo> {
     return this.request({
       path: `/service/info/boards/${id}`,
       method: 'get',
@@ -1579,7 +1590,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceInfoBoardsActive(params: CommonParameters = {}): Promise<Array<BoardInfo>> {
+  getServiceInfoBoardsActive(params: CommonParameters<BoardInfo> = {}): Promise<Array<BoardInfo>> {
     return this.request({
       path: `/service/info/boards/active`,
       method: 'get',
@@ -1587,7 +1598,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceInfoBoardsCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceInfoBoardsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/info/boards/count`,
       method: 'get',
@@ -1595,7 +1606,9 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceInfoBoardtypes(params: CommonParameters = {}): Promise<Array<BoardTypeInfo>> {
+  getServiceInfoBoardtypes(
+    params: CommonParameters<BoardTypeInfo> = {},
+  ): Promise<Array<BoardTypeInfo>> {
     return this.request({
       path: `/service/info/boardtypes`,
       method: 'get',
@@ -1603,7 +1616,10 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceInfoBoardtypesById(id: number, params: CommonParameters = {}): Promise<BoardTypeInfo> {
+  getServiceInfoBoardtypesById(
+    id: number,
+    params: CommonParameters<BoardTypeInfo> = {},
+  ): Promise<BoardTypeInfo> {
     return this.request({
       path: `/service/info/boardtypes/${id}`,
       method: 'get',
@@ -1611,7 +1627,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceInfoBoardtypesCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceInfoBoardtypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/info/boardtypes/count`,
       method: 'get',
@@ -1620,7 +1636,7 @@ export class ServiceAPI extends ManageBaseAPI {
   }
 
   getServiceKnowledgeBaseArticles(
-    params: CommonParameters = {},
+    params: CommonParameters<KnowledgeBaseArticle> = {},
   ): Promise<Array<KnowledgeBaseArticle>> {
     return this.request({
       path: `/service/knowledgeBaseArticles`,
@@ -1641,7 +1657,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceKnowledgeBaseArticlesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<KnowledgeBaseArticle> = {},
   ): Promise<KnowledgeBaseArticle> {
     return this.request({
       path: `/service/knowledgeBaseArticles/${id}`,
@@ -1679,7 +1695,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceKnowledgeBaseArticlesCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceKnowledgeBaseArticlesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/knowledgeBaseArticles/count`,
       method: 'get',
@@ -1688,7 +1704,7 @@ export class ServiceAPI extends ManageBaseAPI {
   }
 
   getServiceKnowledgeBaseCategories(
-    params: CommonParameters = {},
+    params: CommonParameters<KnowledgeBaseCategory> = {},
   ): Promise<Array<KnowledgeBaseCategory>> {
     return this.request({
       path: `/service/knowledgeBaseCategories`,
@@ -1709,7 +1725,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceKnowledgeBaseCategoriesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<KnowledgeBaseCategory> = {},
   ): Promise<KnowledgeBaseCategory> {
     return this.request({
       path: `/service/knowledgeBaseCategories/${id}`,
@@ -1747,7 +1763,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceKnowledgeBaseCategoriesCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceKnowledgeBaseCategoriesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/knowledgeBaseCategories/count`,
       method: 'get',
@@ -1755,7 +1771,9 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceKnowledgebasesettings(params: CommonParameters = {}): Promise<KnowledgeBaseSettings> {
+  getServiceKnowledgebasesettings(
+    params: CommonParameters<KnowledgeBaseSettings> = {},
+  ): Promise<KnowledgeBaseSettings> {
     return this.request({
       path: `/service/knowledgebasesettings`,
       method: 'get',
@@ -1775,7 +1793,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceKnowledgebasesettingsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<KnowledgeBaseSettings> = {},
   ): Promise<KnowledgeBaseSettings> {
     return this.request({
       path: `/service/knowledgebasesettings/${id}`,
@@ -1807,7 +1825,7 @@ export class ServiceAPI extends ManageBaseAPI {
   }
 
   getServiceKnowledgeBaseSubCategories(
-    params: CommonParameters = {},
+    params: CommonParameters<KnowledgeBaseSubCategory> = {},
   ): Promise<Array<KnowledgeBaseSubCategory>> {
     return this.request({
       path: `/service/knowledgeBaseSubCategories`,
@@ -1828,7 +1846,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceKnowledgeBaseSubCategoriesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<KnowledgeBaseSubCategory> = {},
   ): Promise<KnowledgeBaseSubCategory> {
     return this.request({
       path: `/service/knowledgeBaseSubCategories/${id}`,
@@ -1868,7 +1886,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceKnowledgeBaseSubCategoriesByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/knowledgeBaseSubCategories/${id}/usages`,
@@ -1879,7 +1897,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceKnowledgeBaseSubCategoriesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/knowledgeBaseSubCategories/${id}/usages/list`,
@@ -1888,7 +1906,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceKnowledgeBaseSubCategoriesCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceKnowledgeBaseSubCategoriesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/knowledgeBaseSubCategories/count`,
       method: 'get',
@@ -1896,7 +1914,9 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceLocations(params: CommonParameters = {}): Promise<Array<ServiceLocation>> {
+  getServiceLocations(
+    params: CommonParameters<ServiceLocation> = {},
+  ): Promise<Array<ServiceLocation>> {
     return this.request({
       path: `/service/locations`,
       method: 'get',
@@ -1912,7 +1932,10 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceLocationsById(id: number, params: CommonParameters = {}): Promise<ServiceLocation> {
+  getServiceLocationsById(
+    id: number,
+    params: CommonParameters<ServiceLocation> = {},
+  ): Promise<ServiceLocation> {
     return this.request({
       path: `/service/locations/${id}`,
       method: 'get',
@@ -1948,7 +1971,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceLocationsByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ServiceLocationInfo> = {},
   ): Promise<ServiceLocationInfo> {
     return this.request({
       path: `/service/locations/${id}/info`,
@@ -1957,7 +1980,10 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceLocationsByIdUsages(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getServiceLocationsByIdUsages(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/locations/${id}/usages`,
       method: 'get',
@@ -1967,7 +1993,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceLocationsByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/locations/${id}/usages/list`,
@@ -1976,7 +2002,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceLocationsCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceLocationsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/locations/count`,
       method: 'get',
@@ -1984,7 +2010,9 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceLocationsInfo(params: CommonParameters = {}): Promise<Array<ServiceLocationInfo>> {
+  getServiceLocationsInfo(
+    params: CommonParameters<ServiceLocationInfo> = {},
+  ): Promise<Array<ServiceLocationInfo>> {
     return this.request({
       path: `/service/locations/info`,
       method: 'get',
@@ -1992,7 +2020,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceLocationsInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceLocationsInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/locations/info/count`,
       method: 'get',
@@ -2000,7 +2028,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServicePriorities(params: CommonParameters = {}): Promise<Array<Priority>> {
+  getServicePriorities(params: CommonParameters<Priority> = {}): Promise<Array<Priority>> {
     return this.request({
       path: `/service/priorities`,
       method: 'get',
@@ -2016,7 +2044,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServicePrioritiesById(id: number, params: CommonParameters = {}): Promise<Priority> {
+  getServicePrioritiesById(id: number, params: CommonParameters<Priority> = {}): Promise<Priority> {
     return this.request({
       path: `/service/priorities/${id}`,
       method: 'get',
@@ -2052,7 +2080,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServicePrioritiesByIdImage(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<OctetStreamResponse> = {},
   ): Promise<OctetStreamResponse> {
     return this.request({
       path: `/service/priorities/${id}/image`,
@@ -2061,7 +2089,10 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServicePrioritiesByIdUsages(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getServicePrioritiesByIdUsages(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/priorities/${id}/usages`,
       method: 'get',
@@ -2071,7 +2102,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServicePrioritiesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/priorities/${id}/usages/list`,
@@ -2080,7 +2111,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServicePrioritiesCount(params: CommonParameters = {}): Promise<Count> {
+  getServicePrioritiesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/priorities/count`,
       method: 'get',
@@ -2088,7 +2119,10 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServicePriorityByIdInfo(id: number, params: CommonParameters = {}): Promise<PriorityInfo> {
+  getServicePriorityByIdInfo(
+    id: number,
+    params: CommonParameters<PriorityInfo> = {},
+  ): Promise<PriorityInfo> {
     return this.request({
       path: `/service/priority/${id}/info`,
       method: 'get',
@@ -2096,7 +2130,9 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServicePriorityInfo(params: CommonParameters = {}): Promise<Array<PriorityInfo>> {
+  getServicePriorityInfo(
+    params: CommonParameters<PriorityInfo> = {},
+  ): Promise<Array<PriorityInfo>> {
     return this.request({
       path: `/service/priority/info`,
       method: 'get',
@@ -2106,7 +2142,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceSchedulingMembersByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<SchedulingMemberInfo> = {},
   ): Promise<SchedulingMemberInfo> {
     return this.request({
       path: `/service/scheduling/members/${id}/info`,
@@ -2116,7 +2152,7 @@ export class ServiceAPI extends ManageBaseAPI {
   }
 
   getServiceSchedulingMembersInfo(
-    params: CommonParameters = {},
+    params: CommonParameters<SchedulingMemberInfo> = {},
   ): Promise<Array<SchedulingMemberInfo>> {
     return this.request({
       path: `/service/scheduling/members/info`,
@@ -2125,7 +2161,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceSchedulingMembersInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceSchedulingMembersInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/scheduling/members/info/count`,
       method: 'get',
@@ -2133,7 +2169,9 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceServiceSignoff(params: CommonParameters = {}): Promise<Array<ServiceSignoff>> {
+  getServiceServiceSignoff(
+    params: CommonParameters<ServiceSignoff> = {},
+  ): Promise<Array<ServiceSignoff>> {
     return this.request({
       path: `/service/serviceSignoff`,
       method: 'get',
@@ -2149,7 +2187,10 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceServiceSignoffById(id: number, params: CommonParameters = {}): Promise<ServiceSignoff> {
+  getServiceServiceSignoffById(
+    id: number,
+    params: CommonParameters<ServiceSignoff> = {},
+  ): Promise<ServiceSignoff> {
     return this.request({
       path: `/service/serviceSignoff/${id}`,
       method: 'get',
@@ -2188,7 +2229,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceServiceSignoffByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ServiceSignoffInfo> = {},
   ): Promise<ServiceSignoffInfo> {
     return this.request({
       path: `/service/serviceSignoff/${id}/info`,
@@ -2199,7 +2240,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceServiceSignoffByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/serviceSignoff/${id}/usages`,
@@ -2210,7 +2251,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceServiceSignoffByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/serviceSignoff/${id}/usages/list`,
@@ -2221,7 +2262,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceServiceSignoffByParentIdSignoffcustomfields(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ServiceSignoffCustomField> = {},
   ): Promise<Array<ServiceSignoffCustomField>> {
     return this.request({
       path: `/service/serviceSignoff/${parentId}/signoffcustomfields`,
@@ -2244,7 +2285,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceServiceSignoffByParentIdSignoffcustomfieldsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ServiceSignoffCustomField> = {},
   ): Promise<ServiceSignoffCustomField> {
     return this.request({
       path: `/service/serviceSignoff/${parentId}/signoffcustomfields/${id}`,
@@ -2289,7 +2330,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceServiceSignoffByParentIdSignoffcustomfieldsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/serviceSignoff/${parentId}/signoffcustomfields/count`,
@@ -2298,7 +2339,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceServiceSignoffCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceServiceSignoffCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/serviceSignoff/count`,
       method: 'get',
@@ -2306,7 +2347,9 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceServiceSignoffInfo(params: CommonParameters = {}): Promise<Array<ServiceSignoffInfo>> {
+  getServiceServiceSignoffInfo(
+    params: CommonParameters<ServiceSignoffInfo> = {},
+  ): Promise<Array<ServiceSignoffInfo>> {
     return this.request({
       path: `/service/serviceSignoff/info`,
       method: 'get',
@@ -2314,7 +2357,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceServiceSignoffInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceServiceSignoffInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/serviceSignoff/info/count`,
       method: 'get',
@@ -2322,7 +2365,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceSeverities(params: CommonParameters = {}): Promise<Array<Severity>> {
+  getServiceSeverities(params: CommonParameters<Severity> = {}): Promise<Array<Severity>> {
     return this.request({
       path: `/service/severities`,
       method: 'get',
@@ -2330,7 +2373,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceSeveritiesById(id: number, params: CommonParameters = {}): Promise<Severity> {
+  getServiceSeveritiesById(id: number, params: CommonParameters<Severity> = {}): Promise<Severity> {
     return this.request({
       path: `/service/severities/${id}`,
       method: 'get',
@@ -2357,7 +2400,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceSeveritiesCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceSeveritiesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/severities/count`,
       method: 'get',
@@ -2365,7 +2408,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceSLAs(params: CommonParameters = {}): Promise<Array<SLA>> {
+  getServiceSLAs(params: CommonParameters<SLA> = {}): Promise<Array<SLA>> {
     return this.request({
       path: `/service/SLAs`,
       method: 'get',
@@ -2381,7 +2424,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceSLAsById(id: number, params: CommonParameters = {}): Promise<SLA> {
+  getServiceSLAsById(id: number, params: CommonParameters<SLA> = {}): Promise<SLA> {
     return this.request({
       path: `/service/SLAs/${id}`,
       method: 'get',
@@ -2412,7 +2455,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceSlasByIdInfo(id: number, params: CommonParameters = {}): Promise<SLAInfo> {
+  getServiceSlasByIdInfo(id: number, params: CommonParameters<SLAInfo> = {}): Promise<SLAInfo> {
     return this.request({
       path: `/service/slas/${id}/info`,
       method: 'get',
@@ -2420,7 +2463,10 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceSLAsByIdUsages(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getServiceSLAsByIdUsages(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/SLAs/${id}/usages`,
       method: 'get',
@@ -2428,7 +2474,10 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceSLAsByIdUsagesList(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getServiceSLAsByIdUsagesList(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/SLAs/${id}/usages/list`,
       method: 'get',
@@ -2438,7 +2487,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceSLAsByParentIdPriorities(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<SLAPriority> = {},
   ): Promise<Array<SLAPriority>> {
     return this.request({
       path: `/service/SLAs/${parentId}/priorities`,
@@ -2461,7 +2510,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceSLAsByParentIdPrioritiesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<SLAPriority> = {},
   ): Promise<SLAPriority> {
     return this.request({
       path: `/service/SLAs/${parentId}/priorities/${id}`,
@@ -2506,7 +2555,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceSLAsByParentIdPrioritiesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/SLAs/${parentId}/priorities/count`,
@@ -2515,7 +2564,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceSLAsCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceSLAsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/SLAs/count`,
       method: 'get',
@@ -2523,7 +2572,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceSlasInfo(params: CommonParameters = {}): Promise<Array<SLAInfo>> {
+  getServiceSlasInfo(params: CommonParameters<SLAInfo> = {}): Promise<Array<SLAInfo>> {
     return this.request({
       path: `/service/slas/info`,
       method: 'get',
@@ -2531,7 +2580,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceSLAsInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceSLAsInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/SLAs/info/count`,
       method: 'get',
@@ -2539,7 +2588,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceSources(params: CommonParameters = {}): Promise<Array<Source>> {
+  getServiceSources(params: CommonParameters<Source> = {}): Promise<Array<Source>> {
     return this.request({
       path: `/service/sources`,
       method: 'get',
@@ -2555,7 +2604,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceSourcesById(id: number, params: CommonParameters = {}): Promise<Source> {
+  getServiceSourcesById(id: number, params: CommonParameters<Source> = {}): Promise<Source> {
     return this.request({
       path: `/service/sources/${id}`,
       method: 'get',
@@ -2586,7 +2635,10 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceSourcesByIdInfo(id: number, params: CommonParameters = {}): Promise<SourceInfo> {
+  getServiceSourcesByIdInfo(
+    id: number,
+    params: CommonParameters<SourceInfo> = {},
+  ): Promise<SourceInfo> {
     return this.request({
       path: `/service/sources/${id}/info`,
       method: 'get',
@@ -2594,7 +2646,10 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceSourcesByIdUsages(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getServiceSourcesByIdUsages(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/sources/${id}/usages`,
       method: 'get',
@@ -2604,7 +2659,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceSourcesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/sources/${id}/usages/list`,
@@ -2613,7 +2668,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceSourcesCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceSourcesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/sources/count`,
       method: 'get',
@@ -2621,7 +2676,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceSourcesInfo(params: CommonParameters = {}): Promise<Array<SourceInfo>> {
+  getServiceSourcesInfo(params: CommonParameters<SourceInfo> = {}): Promise<Array<SourceInfo>> {
     return this.request({
       path: `/service/sources/info`,
       method: 'get',
@@ -2629,7 +2684,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceSourcesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceSourcesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/sources/info/count`,
       method: 'get',
@@ -2637,7 +2692,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceSurveys(params: CommonParameters = {}): Promise<Array<ServiceSurvey>> {
+  getServiceSurveys(params: CommonParameters<ServiceSurvey> = {}): Promise<Array<ServiceSurvey>> {
     return this.request({
       path: `/service/surveys`,
       method: 'get',
@@ -2656,7 +2711,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceSurveysByGrandparentIdQuestionsByParentIdOptions(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<SurveyOption> = {},
   ): Promise<Array<SurveyOption>> {
     return this.request({
       path: `/service/surveys/${grandparentId}/questions/${parentId}/options`,
@@ -2681,7 +2736,7 @@ export class ServiceAPI extends ManageBaseAPI {
     id: number,
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<SurveyOption> = {},
   ): Promise<SurveyOption> {
     return this.request({
       path: `/service/surveys/${grandparentId}/questions/${parentId}/options/${id}`,
@@ -2730,7 +2785,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceSurveysByGrandparentIdQuestionsByParentIdOptionsCount(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/surveys/${grandparentId}/questions/${parentId}/options/count`,
@@ -2739,7 +2794,10 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceSurveysById(id: number, params: CommonParameters = {}): Promise<ServiceSurvey> {
+  getServiceSurveysById(
+    id: number,
+    params: CommonParameters<ServiceSurvey> = {},
+  ): Promise<ServiceSurvey> {
     return this.request({
       path: `/service/surveys/${id}`,
       method: 'get',
@@ -2780,7 +2838,10 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceSurveysByIdUsages(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getServiceSurveysByIdUsages(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/surveys/${id}/usages`,
       method: 'get',
@@ -2790,7 +2851,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceSurveysByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/service/surveys/${id}/usages/list`,
@@ -2801,7 +2862,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceSurveysByParentIdQuestions(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ServiceSurveyQuestion> = {},
   ): Promise<Array<ServiceSurveyQuestion>> {
     return this.request({
       path: `/service/surveys/${parentId}/questions`,
@@ -2824,7 +2885,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceSurveysByParentIdQuestionsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ServiceSurveyQuestion> = {},
   ): Promise<ServiceSurveyQuestion> {
     return this.request({
       path: `/service/surveys/${parentId}/questions/${id}`,
@@ -2879,7 +2940,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceSurveysByParentIdQuestionsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/surveys/${parentId}/questions/count`,
@@ -2890,7 +2951,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceSurveysByParentIdResults(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<SurveyResult> = {},
   ): Promise<Array<SurveyResult>> {
     return this.request({
       path: `/service/surveys/${parentId}/results`,
@@ -2913,7 +2974,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceSurveysByParentIdResultsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<SurveyResult> = {},
   ): Promise<SurveyResult> {
     return this.request({
       path: `/service/surveys/${parentId}/results/${id}`,
@@ -2958,7 +3019,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceSurveysByParentIdResultsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/surveys/${parentId}/results/count`,
@@ -2967,7 +3028,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceSurveysCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceSurveysCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/surveys/count`,
       method: 'get',
@@ -2983,7 +3044,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceTeams(params: CommonParameters = {}): Promise<Array<ServiceTeam>> {
+  getServiceTeams(params: CommonParameters<ServiceTeam> = {}): Promise<Array<ServiceTeam>> {
     return this.request({
       path: `/service/teams`,
       method: 'get',
@@ -2991,7 +3052,10 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceTeamsById(id: number, params: CommonParameters = {}): Promise<ServiceTeam> {
+  getServiceTeamsById(
+    id: number,
+    params: CommonParameters<ServiceTeam> = {},
+  ): Promise<ServiceTeam> {
     return this.request({
       path: `/service/teams/${id}`,
       method: 'get',
@@ -2999,7 +3063,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceTeamsCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceTeamsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/teams/count`,
       method: 'get',
@@ -3007,7 +3071,9 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceTemplates(params: CommonParameters = {}): Promise<Array<ServiceTemplate>> {
+  getServiceTemplates(
+    params: CommonParameters<ServiceTemplate> = {},
+  ): Promise<Array<ServiceTemplate>> {
     return this.request({
       path: `/service/templates`,
       method: 'get',
@@ -3023,7 +3089,10 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceTemplatesById(id: number, params: CommonParameters = {}): Promise<ServiceTemplate> {
+  getServiceTemplatesById(
+    id: number,
+    params: CommonParameters<ServiceTemplate> = {},
+  ): Promise<ServiceTemplate> {
     return this.request({
       path: `/service/templates/${id}`,
       method: 'get',
@@ -3070,7 +3139,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceTemplatesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ServiceTemplateInfo> = {},
   ): Promise<ServiceTemplateInfo> {
     return this.request({
       path: `/service/templates/${id}/info`,
@@ -3081,7 +3150,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceTemplatesByParentIdTasks(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ServiceTemplateTask> = {},
   ): Promise<Array<ServiceTemplateTask>> {
     return this.request({
       path: `/service/templates/${parentId}/tasks`,
@@ -3104,7 +3173,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceTemplatesByParentIdTasksById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ServiceTemplateTask> = {},
   ): Promise<ServiceTemplateTask> {
     return this.request({
       path: `/service/templates/${parentId}/tasks/${id}`,
@@ -3149,7 +3218,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceTemplatesByParentIdTasksCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/templates/${parentId}/tasks/count`,
@@ -3158,7 +3227,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceTemplatesCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceTemplatesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/templates/count`,
       method: 'get',
@@ -3166,7 +3235,9 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceTemplatesInfo(params: CommonParameters = {}): Promise<Array<ServiceTemplateInfo>> {
+  getServiceTemplatesInfo(
+    params: CommonParameters<ServiceTemplateInfo> = {},
+  ): Promise<Array<ServiceTemplateInfo>> {
     return this.request({
       path: `/service/templates/info`,
       method: 'get',
@@ -3174,7 +3245,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceTemplatesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceTemplatesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/templates/info/count`,
       method: 'get',
@@ -3182,7 +3253,9 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceTicketLinks(params: CommonParameters = {}): Promise<Array<ServiceTicketLink>> {
+  getServiceTicketLinks(
+    params: CommonParameters<ServiceTicketLink> = {},
+  ): Promise<Array<ServiceTicketLink>> {
     return this.request({
       path: `/service/ticketLinks`,
       method: 'get',
@@ -3198,7 +3271,10 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceTicketLinksById(id: number, params: CommonParameters = {}): Promise<ServiceTicketLink> {
+  getServiceTicketLinksById(
+    id: number,
+    params: CommonParameters<ServiceTicketLink> = {},
+  ): Promise<ServiceTicketLink> {
     return this.request({
       path: `/service/ticketLinks/${id}`,
       method: 'get',
@@ -3237,7 +3313,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceTicketLinksByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ServiceTicketLinkInfo> = {},
   ): Promise<ServiceTicketLinkInfo> {
     return this.request({
       path: `/service/ticketLinks/${id}/info`,
@@ -3246,7 +3322,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceTicketLinksCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceTicketLinksCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/ticketLinks/count`,
       method: 'get',
@@ -3254,7 +3330,9 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceTicketLinksInfo(params: CommonParameters = {}): Promise<Array<ServiceTicketLinkInfo>> {
+  getServiceTicketLinksInfo(
+    params: CommonParameters<ServiceTicketLinkInfo> = {},
+  ): Promise<Array<ServiceTicketLinkInfo>> {
     return this.request({
       path: `/service/ticketLinks/info`,
       method: 'get',
@@ -3262,7 +3340,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceTicketLinksInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceTicketLinksInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/ticketLinks/info/count`,
       method: 'get',
@@ -3270,7 +3348,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceTickets(params: CommonParameters = {}): Promise<Array<Ticket>> {
+  getServiceTickets(params: CommonParameters<Ticket> = {}): Promise<Array<Ticket>> {
     return this.request({
       path: `/service/tickets`,
       method: 'get',
@@ -3286,7 +3364,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceTicketsById(id: number, params: CommonParameters = {}): Promise<Ticket> {
+  getServiceTicketsById(id: number, params: CommonParameters<Ticket> = {}): Promise<Ticket> {
     return this.request({
       path: `/service/tickets/${id}`,
       method: 'get',
@@ -3324,7 +3402,10 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceTicketsByIdInfo(id: number, params: CommonParameters = {}): Promise<TicketInfo> {
+  getServiceTicketsByIdInfo(
+    id: number,
+    params: CommonParameters<TicketInfo> = {},
+  ): Promise<TicketInfo> {
     return this.request({
       path: `/service/tickets/${id}/info`,
       method: 'get',
@@ -3334,7 +3415,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceTicketsByParentIdActivities(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ActivityReference> = {},
   ): Promise<Array<ActivityReference>> {
     return this.request({
       path: `/service/tickets/${parentId}/activities`,
@@ -3345,7 +3426,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceTicketsByParentIdActivitiesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/tickets/${parentId}/activities/count`,
@@ -3356,7 +3437,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceTicketsByParentIdAllNotes(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ServiceTicketNote> = {},
   ): Promise<Array<ServiceTicketNote>> {
     return this.request({
       path: `/service/tickets/${parentId}/allNotes`,
@@ -3378,7 +3459,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceTicketsByParentIdConfigurations(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ConfigurationReference> = {},
   ): Promise<Array<ConfigurationReference>> {
     return this.request({
       path: `/service/tickets/${parentId}/configurations`,
@@ -3401,7 +3482,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceTicketsByParentIdConfigurationsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ConfigurationReference> = {},
   ): Promise<ConfigurationReference> {
     return this.request({
       path: `/service/tickets/${parentId}/configurations/${id}`,
@@ -3422,7 +3503,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceTicketsByParentIdConfigurationsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/tickets/${parentId}/configurations/count`,
@@ -3444,7 +3525,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceTicketsByParentIdDocuments(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<DocumentReference> = {},
   ): Promise<Array<DocumentReference>> {
     return this.request({
       path: `/service/tickets/${parentId}/documents`,
@@ -3455,7 +3536,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceTicketsByParentIdDocumentsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/tickets/${parentId}/documents/count`,
@@ -3477,7 +3558,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceTicketsByParentIdNotes(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ServiceNote> = {},
   ): Promise<Array<ServiceNote>> {
     return this.request({
       path: `/service/tickets/${parentId}/notes`,
@@ -3500,7 +3581,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceTicketsByParentIdNotesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ServiceNote> = {},
   ): Promise<ServiceNote> {
     return this.request({
       path: `/service/tickets/${parentId}/notes/${id}`,
@@ -3545,7 +3626,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceTicketsByParentIdNotesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/tickets/${parentId}/notes/count`,
@@ -3556,7 +3637,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceTicketsByParentIdProducts(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ProductReference> = {},
   ): Promise<Array<ProductReference>> {
     return this.request({
       path: `/service/tickets/${parentId}/products`,
@@ -3567,7 +3648,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceTicketsByParentIdProductsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/tickets/${parentId}/products/count`,
@@ -3578,7 +3659,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceTicketsByParentIdScheduleentries(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ScheduleEntryReference> = {},
   ): Promise<Array<ScheduleEntryReference>> {
     return this.request({
       path: `/service/tickets/${parentId}/scheduleentries`,
@@ -3589,7 +3670,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceTicketsByParentIdScheduleentriesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/tickets/${parentId}/scheduleentries/count`,
@@ -3600,7 +3681,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceTicketsByParentIdTasks(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ServiceTask> = {},
   ): Promise<Array<ServiceTask>> {
     return this.request({
       path: `/service/tickets/${parentId}/tasks`,
@@ -3620,7 +3701,7 @@ export class ServiceAPI extends ManageBaseAPI {
   getServiceTicketsByParentIdTasksById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ServiceTask> = {},
   ): Promise<ServiceTask> {
     return this.request({
       path: `/service/tickets/${parentId}/tasks/${id}`,
@@ -3665,7 +3746,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceTicketsByParentIdTasksCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/tickets/${parentId}/tasks/count`,
@@ -3676,7 +3757,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceTicketsByParentIdTimeentries(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TimeEntryReference> = {},
   ): Promise<Array<TimeEntryReference>> {
     return this.request({
       path: `/service/tickets/${parentId}/timeentries`,
@@ -3687,7 +3768,7 @@ export class ServiceAPI extends ManageBaseAPI {
 
   getServiceTicketsByParentIdTimeentriesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/service/tickets/${parentId}/timeentries/count`,
@@ -3696,7 +3777,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceTicketsCalculateSla(params: CommonParameters = {}): Promise<Array<Ticket>> {
+  getServiceTicketsCalculateSla(params: CommonParameters<Ticket> = {}): Promise<Array<Ticket>> {
     return this.request({
       path: `/service/tickets/calculateSla`,
       method: 'get',
@@ -3704,7 +3785,9 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceTicketsChangelogs(params: CommonParameters = {}): Promise<Array<TicketChangeLog>> {
+  getServiceTicketsChangelogs(
+    params: CommonParameters<TicketChangeLog> = {},
+  ): Promise<Array<TicketChangeLog>> {
     return this.request({
       path: `/service/tickets/changelogs`,
       method: 'get',
@@ -3719,7 +3802,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceTicketsCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceTicketsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/tickets/count`,
       method: 'get',
@@ -3727,7 +3810,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceTicketsInfo(params: CommonParameters = {}): Promise<Array<TicketInfo>> {
+  getServiceTicketsInfo(params: CommonParameters<TicketInfo> = {}): Promise<Array<TicketInfo>> {
     return this.request({
       path: `/service/tickets/info`,
       method: 'get',
@@ -3735,7 +3818,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceTicketsInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceTicketsInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/tickets/info/count`,
       method: 'get',
@@ -3751,7 +3834,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceTicketSyncs(params: CommonParameters = {}): Promise<Array<TicketSync>> {
+  getServiceTicketSyncs(params: CommonParameters<TicketSync> = {}): Promise<Array<TicketSync>> {
     return this.request({
       path: `/service/ticketSyncs`,
       method: 'get',
@@ -3767,7 +3850,10 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceTicketSyncsById(id: number, params: CommonParameters = {}): Promise<TicketSync> {
+  getServiceTicketSyncsById(
+    id: number,
+    params: CommonParameters<TicketSync> = {},
+  ): Promise<TicketSync> {
     return this.request({
       path: `/service/ticketSyncs/${id}`,
       method: 'get',
@@ -3801,7 +3887,7 @@ export class ServiceAPI extends ManageBaseAPI {
     })
   }
 
-  getServiceTicketSyncsCount(params: CommonParameters = {}): Promise<Count> {
+  getServiceTicketSyncsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/service/ticketSyncs/count`,
       method: 'get',

--- a/src/Manage/SystemAPI.ts
+++ b/src/Manage/SystemAPI.ts
@@ -316,7 +316,9 @@ export type WorkflowTriggerOption = schemas['WorkflowTriggerOption']
  * @public
  */
 export class SystemAPI extends ManageBaseAPI {
-  getSystemAllowedfiletypes(params: CommonParameters = {}): Promise<Array<AllowedFileType>> {
+  getSystemAllowedfiletypes(
+    params: CommonParameters<AllowedFileType> = {},
+  ): Promise<Array<AllowedFileType>> {
     return this.request({
       path: `/system/allowedfiletypes/`,
       method: 'get',
@@ -334,7 +336,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemAllowedfiletypesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<AllowedFileType> = {},
   ): Promise<AllowedFileType> {
     return this.request({
       path: `/system/allowedfiletypes/${id}`,
@@ -372,7 +374,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemAllowedfiletypesCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemAllowedfiletypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/allowedfiletypes/count`,
       method: 'get',
@@ -380,7 +382,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemAllowedorigins(params: CommonParameters = {}): Promise<Array<AllowedOrigin>> {
+  getSystemAllowedorigins(
+    params: CommonParameters<AllowedOrigin> = {},
+  ): Promise<Array<AllowedOrigin>> {
     return this.request({
       path: `/system/allowedorigins`,
       method: 'get',
@@ -396,7 +400,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemAllowedoriginsById(id: number, params: CommonParameters = {}): Promise<AllowedOrigin> {
+  getSystemAllowedoriginsById(
+    id: number,
+    params: CommonParameters<AllowedOrigin> = {},
+  ): Promise<AllowedOrigin> {
     return this.request({
       path: `/system/allowedorigins/${id}`,
       method: 'get',
@@ -430,7 +437,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemAllowedoriginsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemAllowedoriginsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/allowedorigins/count`,
       method: 'get',
@@ -438,7 +445,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemApiMembers(params: CommonParameters = {}): Promise<Array<ApiMember>> {
+  getSystemApiMembers(params: CommonParameters<ApiMember> = {}): Promise<Array<ApiMember>> {
     return this.request({
       path: `/system/apiMembers`,
       method: 'get',
@@ -454,7 +461,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemApiMembersById(id: number, params: CommonParameters = {}): Promise<ApiMember> {
+  getSystemApiMembersById(
+    id: number,
+    params: CommonParameters<ApiMember> = {},
+  ): Promise<ApiMember> {
     return this.request({
       path: `/system/apiMembers/${id}`,
       method: 'get',
@@ -481,7 +491,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemApiMembersCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemApiMembersCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/apiMembers/count`,
       method: 'get',
@@ -489,7 +499,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemApiMembersDefault(params: CommonParameters = {}): Promise<ApiMember> {
+  getSystemApiMembersDefault(params: CommonParameters<ApiMember> = {}): Promise<ApiMember> {
     return this.request({
       path: `/system/apiMembers/default`,
       method: 'get',
@@ -497,7 +507,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemAudittrail(params: CommonParameters = {}): Promise<Array<AuditTrailEntry>> {
+  getSystemAudittrail(
+    params: CommonParameters<AuditTrailEntry> = {},
+  ): Promise<Array<AuditTrailEntry>> {
     return this.request({
       path: `/system/audittrail`,
       method: 'get',
@@ -505,7 +517,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemAudittrailCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemAudittrailCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/audittrail/count`,
       method: 'get',
@@ -513,7 +525,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemAuthAnvils(params: CommonParameters = {}): Promise<Array<AuthAnvil>> {
+  getSystemAuthAnvils(params: CommonParameters<AuthAnvil> = {}): Promise<Array<AuthAnvil>> {
     return this.request({
       path: `/system/authAnvils`,
       method: 'get',
@@ -521,7 +533,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemAuthAnvilsById(id: number, params: CommonParameters = {}): Promise<AuthAnvil> {
+  getSystemAuthAnvilsById(
+    id: number,
+    params: CommonParameters<AuthAnvil> = {},
+  ): Promise<AuthAnvil> {
     return this.request({
       path: `/system/authAnvils/${id}`,
       method: 'get',
@@ -548,7 +563,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemAuthAnvilsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemAuthAnvilsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/authAnvils/count`,
       method: 'get',
@@ -556,7 +571,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemAuthAnvilsTestConnection(params: CommonParameters = {}): Promise<SuccessResponse> {
+  getSystemAuthAnvilsTestConnection(
+    params: CommonParameters<SuccessResponse> = {},
+  ): Promise<SuccessResponse> {
     return this.request({
       path: `/system/authAnvils/testConnection`,
       method: 'get',
@@ -564,7 +581,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemAutoSyncTime(params: CommonParameters = {}): Promise<Array<AutoSyncTime>> {
+  getSystemAutoSyncTime(params: CommonParameters<AutoSyncTime> = {}): Promise<Array<AutoSyncTime>> {
     return this.request({
       path: `/system/autoSyncTime`,
       method: 'get',
@@ -580,7 +597,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemAutoSyncTimeById(id: number, params: CommonParameters = {}): Promise<AutoSyncTime> {
+  getSystemAutoSyncTimeById(
+    id: number,
+    params: CommonParameters<AutoSyncTime> = {},
+  ): Promise<AutoSyncTime> {
     return this.request({
       path: `/system/autoSyncTime/${id}`,
       method: 'get',
@@ -614,7 +634,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemAutoSyncTimeCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemAutoSyncTimeCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/autoSyncTime/count`,
       method: 'get',
@@ -622,7 +642,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemBillableOptionsInfo(params: CommonParameters = {}): Promise<Array<BillableOptionsInfo>> {
+  getSystemBillableOptionsInfo(
+    params: CommonParameters<BillableOptionsInfo> = {},
+  ): Promise<Array<BillableOptionsInfo>> {
     return this.request({
       path: `/system/BillableOptions/info`,
       method: 'get',
@@ -646,7 +668,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemCallbacks(params: CommonParameters = {}): Promise<Array<CallbackEntry>> {
+  getSystemCallbacks(params: CommonParameters<CallbackEntry> = {}): Promise<Array<CallbackEntry>> {
     return this.request({
       path: `/system/callbacks`,
       method: 'get',
@@ -662,7 +684,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemCallbacksById(id: number, params: CommonParameters = {}): Promise<CallbackEntry> {
+  getSystemCallbacksById(
+    id: number,
+    params: CommonParameters<CallbackEntry> = {},
+  ): Promise<CallbackEntry> {
     return this.request({
       path: `/system/callbacks/${id}`,
       method: 'get',
@@ -696,7 +721,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemCallbacksCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemCallbacksCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/callbacks/count`,
       method: 'get',
@@ -704,7 +729,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemCertifications(params: CommonParameters = {}): Promise<Array<Certification>> {
+  getSystemCertifications(
+    params: CommonParameters<Certification> = {},
+  ): Promise<Array<Certification>> {
     return this.request({
       path: `/system/certifications`,
       method: 'get',
@@ -720,7 +747,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemCertificationsById(id: number, params: CommonParameters = {}): Promise<Certification> {
+  getSystemCertificationsById(
+    id: number,
+    params: CommonParameters<Certification> = {},
+  ): Promise<Certification> {
     return this.request({
       path: `/system/certifications/${id}`,
       method: 'get',
@@ -756,7 +786,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemCertificationsByIdUsages(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/system/certifications/${id}/usages`,
@@ -767,7 +797,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemCertificationsByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/system/certifications/${id}/usages/list`,
@@ -776,7 +806,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemCertificationsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemCertificationsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/certifications/count`,
       method: 'get',
@@ -785,7 +815,7 @@ export class SystemAPI extends ManageBaseAPI {
   }
 
   getSystemConnectWiseHostedScreens(
-    params: CommonParameters = {},
+    params: CommonParameters<ConnectWiseHostedScreen> = {},
   ): Promise<Array<ConnectWiseHostedScreen>> {
     return this.request({
       path: `/system/connectWiseHostedScreens`,
@@ -796,7 +826,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemConnectWiseHostedScreensById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ConnectWiseHostedScreen> = {},
   ): Promise<ConnectWiseHostedScreen> {
     return this.request({
       path: `/system/connectWiseHostedScreens/${id}`,
@@ -805,7 +835,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemConnectWiseHostedScreensCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemConnectWiseHostedScreensCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/connectWiseHostedScreens/count`,
       method: 'get',
@@ -814,7 +844,7 @@ export class SystemAPI extends ManageBaseAPI {
   }
 
   getSystemConnectwisehostedsetups(
-    params: CommonParameters = {},
+    params: CommonParameters<ConnectWiseHostedSetup> = {},
   ): Promise<Array<ConnectWiseHostedSetup>> {
     return this.request({
       path: `/system/connectwisehostedsetups`,
@@ -835,7 +865,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemConnectwisehostedsetupsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ConnectWiseHostedSetup> = {},
   ): Promise<ConnectWiseHostedSetup> {
     return this.request({
       path: `/system/connectwisehostedsetups/${id}`,
@@ -873,7 +903,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemConnectwisehostedsetupsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemConnectwisehostedsetupsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/connectwisehostedsetups/count`,
       method: 'get',
@@ -882,7 +912,7 @@ export class SystemAPI extends ManageBaseAPI {
   }
 
   getSystemContactsyncMonitoring(
-    params: CommonParameters = {},
+    params: CommonParameters<M365ContactSyncMonitoring> = {},
   ): Promise<Array<M365ContactSyncMonitoring>> {
     return this.request({
       path: `/system/contactsync/monitoring`,
@@ -907,7 +937,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemContactsyncMonitoringById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<M365ContactSyncMonitoring> = {},
   ): Promise<M365ContactSyncMonitoring> {
     return this.request({
       path: `/system/contactsync/monitoring/${id}`,
@@ -916,7 +946,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemContactsyncMonitoringCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemContactsyncMonitoringCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/contactsync/monitoring/count`,
       method: 'get',
@@ -925,7 +955,7 @@ export class SystemAPI extends ManageBaseAPI {
   }
 
   getSystemContactsyncMonitoringNotificationtype(
-    params: CommonParameters = {},
+    params: CommonParameters<M365ContactSyncMonitoring> = {},
   ): Promise<M365ContactSyncMonitoring> {
     return this.request({
       path: `/system/contactsync/monitoring/notificationtype/`,
@@ -936,7 +966,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemContactsyncMonitoringTypeById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<M365ContactSyncMonitoring> = {},
   ): Promise<M365ContactSyncMonitoring> {
     return this.request({
       path: `/system/contactsync/monitoring/type/${id}`,
@@ -952,7 +982,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemCustomFieldInfos(params: CommonParameters = {}): Promise<Array<CustomFieldInfo>> {
+  getSystemCustomFieldInfos(
+    params: CommonParameters<CustomFieldInfo> = {},
+  ): Promise<Array<CustomFieldInfo>> {
     return this.request({
       path: `/system/customFieldInfos`,
       method: 'get',
@@ -960,7 +992,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemCustomReports(params: CommonParameters = {}): Promise<Array<CustomReport>> {
+  getSystemCustomReports(
+    params: CommonParameters<CustomReport> = {},
+  ): Promise<Array<CustomReport>> {
     return this.request({
       path: `/system/customReports`,
       method: 'get',
@@ -976,7 +1010,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemCustomReportsById(id: number, params: CommonParameters = {}): Promise<CustomReport> {
+  getSystemCustomReportsById(
+    id: number,
+    params: CommonParameters<CustomReport> = {},
+  ): Promise<CustomReport> {
     return this.request({
       path: `/system/customReports/${id}`,
       method: 'get',
@@ -1012,7 +1049,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemCustomReportsByParentIdParameters(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CustomReportParameter> = {},
   ): Promise<Array<CustomReportParameter>> {
     return this.request({
       path: `/system/customReports/${parentId}/parameters`,
@@ -1035,7 +1072,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemCustomReportsByParentIdParametersById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CustomReportParameter> = {},
   ): Promise<CustomReportParameter> {
     return this.request({
       path: `/system/customReports/${parentId}/parameters/${id}`,
@@ -1080,7 +1117,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemCustomReportsByParentIdParametersCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/customReports/${parentId}/parameters/count`,
@@ -1089,7 +1126,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemCustomReportsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemCustomReportsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/customReports/count`,
       method: 'get',
@@ -1097,7 +1134,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemCwTimeZones(params: CommonParameters = {}): Promise<Array<CwTimeZone>> {
+  getSystemCwTimeZones(params: CommonParameters<CwTimeZone> = {}): Promise<Array<CwTimeZone>> {
     return this.request({
       path: `/system/cwTimeZones`,
       method: 'get',
@@ -1105,7 +1142,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemCwTimeZonesById(id: number, params: CommonParameters = {}): Promise<CwTimeZone> {
+  getSystemCwTimeZonesById(
+    id: number,
+    params: CommonParameters<CwTimeZone> = {},
+  ): Promise<CwTimeZone> {
     return this.request({
       path: `/system/cwTimeZones/${id}`,
       method: 'get',
@@ -1113,7 +1153,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemCwTimeZonesCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemCwTimeZonesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/cwTimeZones/count`,
       method: 'get',
@@ -1121,7 +1161,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemDepartments(params: CommonParameters = {}): Promise<Array<Department>> {
+  getSystemDepartments(params: CommonParameters<Department> = {}): Promise<Array<Department>> {
     return this.request({
       path: `/system/departments`,
       method: 'get',
@@ -1137,7 +1177,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemDepartmentsById(id: number, params: CommonParameters = {}): Promise<Department> {
+  getSystemDepartmentsById(
+    id: number,
+    params: CommonParameters<Department> = {},
+  ): Promise<Department> {
     return this.request({
       path: `/system/departments/${id}`,
       method: 'get',
@@ -1171,7 +1214,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemDepartmentsByIdUsages(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getSystemDepartmentsByIdUsages(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/system/departments/${id}/usages`,
       method: 'get',
@@ -1181,7 +1227,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemDepartmentsByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/system/departments/${id}/usages/list`,
@@ -1192,7 +1238,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemDepartmentsByParentIdLocations(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<DepartmentLocation> = {},
   ): Promise<Array<DepartmentLocation>> {
     return this.request({
       path: `/system/departments/${parentId}/locations`,
@@ -1215,7 +1261,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemDepartmentsByParentIdLocationsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<DepartmentLocation> = {},
   ): Promise<DepartmentLocation> {
     return this.request({
       path: `/system/departments/${parentId}/locations/${id}`,
@@ -1260,7 +1306,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemDepartmentsByParentIdLocationsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/departments/${parentId}/locations/count`,
@@ -1269,7 +1315,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemDepartmentsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemDepartmentsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/departments/count`,
       method: 'get',
@@ -1279,7 +1325,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemDirectionalSyncsByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<DirectionalSyncInfo> = {},
   ): Promise<DirectionalSyncInfo> {
     return this.request({
       path: `/system/directionalSyncs/${id}/info`,
@@ -1289,7 +1335,7 @@ export class SystemAPI extends ManageBaseAPI {
   }
 
   getSystemDirectionalSyncsInfo(
-    params: CommonParameters = {},
+    params: CommonParameters<DirectionalSyncInfo> = {},
   ): Promise<Array<DirectionalSyncInfo>> {
     return this.request({
       path: `/system/directionalSyncs/info`,
@@ -1298,7 +1344,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemDirectionalSyncsInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemDirectionalSyncsInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/directionalSyncs/info/count`,
       method: 'get',
@@ -1306,7 +1352,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemDocuments(params: CommonParameters = {}): Promise<Array<DocumentInfo>> {
+  getSystemDocuments(params: CommonParameters<DocumentInfo> = {}): Promise<Array<DocumentInfo>> {
     return this.request({
       path: `/system/documents`,
       method: 'get',
@@ -1326,7 +1372,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemDocumentsById(id: number, params: CommonParameters = {}): Promise<DocumentInfo> {
+  getSystemDocumentsById(
+    id: number,
+    params: CommonParameters<DocumentInfo> = {},
+  ): Promise<DocumentInfo> {
     return this.request({
       path: `/system/documents/${id}`,
       method: 'get',
@@ -1348,25 +1397,31 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemDocumentsByIdDownload(id: number, params: CommonParameters = {}): Promise<string> {
+  getSystemDocumentsByIdDownload(
+    id: number,
+    params: CommonParameters<string> = {},
+  ): Promise<string> {
     return this.request({
       path: `/system/documents/${id}/download`,
       method: 'get',
-      params,
       responseType: 'arraybuffer',
+      params,
     })
   }
 
-  getSystemDocumentsByIdThumbnail(id: number, params: CommonParameters = {}): Promise<string> {
+  getSystemDocumentsByIdThumbnail(
+    id: number,
+    params: CommonParameters<string> = {},
+  ): Promise<string> {
     return this.request({
       path: `/system/documents/${id}/thumbnail`,
       method: 'get',
-      params,
       responseType: 'arraybuffer',
+      params,
     })
   }
 
-  getSystemDocumentsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemDocumentsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/documents/count`,
       method: 'get',
@@ -1374,7 +1429,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemDocumentsUploadsample(params: CommonParameters = {}): Promise<HTMLResponse> {
+  getSystemDocumentsUploadsample(
+    params: CommonParameters<HTMLResponse> = {},
+  ): Promise<HTMLResponse> {
     return this.request({
       path: `/system/documents/uploadsample`,
       method: 'get',
@@ -1382,7 +1439,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemDocumentTypesByIdInfo(id: number, params: CommonParameters = {}): Promise<DocumentType> {
+  getSystemDocumentTypesByIdInfo(
+    id: number,
+    params: CommonParameters<DocumentType> = {},
+  ): Promise<DocumentType> {
     return this.request({
       path: `/system/documentTypes/${id}/info`,
       method: 'get',
@@ -1390,7 +1450,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemDocumentTypesInfo(params: CommonParameters = {}): Promise<Array<DocumentType>> {
+  getSystemDocumentTypesInfo(
+    params: CommonParameters<DocumentType> = {},
+  ): Promise<Array<DocumentType>> {
     return this.request({
       path: `/system/documentTypes/info`,
       method: 'get',
@@ -1398,7 +1460,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemDocumentTypesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemDocumentTypesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/documentTypes/info/count`,
       method: 'get',
@@ -1406,7 +1468,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemEmailConnectors(params: CommonParameters = {}): Promise<Array<EmailConnector>> {
+  getSystemEmailConnectors(
+    params: CommonParameters<EmailConnector> = {},
+  ): Promise<Array<EmailConnector>> {
     return this.request({
       path: `/system/emailConnectors`,
       method: 'get',
@@ -1425,7 +1489,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemEmailConnectorsByGrandparentIdParsingStylesByParentIdParsingRules(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<EmailConnectorParsingRule> = {},
   ): Promise<Array<EmailConnectorParsingRule>> {
     return this.request({
       path: `/system/emailConnectors/${grandparentId}/parsingStyles/${parentId}/parsingRules`,
@@ -1450,7 +1514,7 @@ export class SystemAPI extends ManageBaseAPI {
     id: number,
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<EmailConnectorParsingRule> = {},
   ): Promise<EmailConnectorParsingRule> {
     return this.request({
       path: `/system/emailConnectors/${grandparentId}/parsingStyles/${parentId}/parsingRules/${id}`,
@@ -1499,7 +1563,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemEmailConnectorsByGrandparentIdParsingStylesByParentIdParsingRulesCount(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/emailConnectors/${grandparentId}/parsingStyles/${parentId}/parsingRules/count`,
@@ -1508,7 +1572,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemEmailConnectorsById(id: number, params: CommonParameters = {}): Promise<EmailConnector> {
+  getSystemEmailConnectorsById(
+    id: number,
+    params: CommonParameters<EmailConnector> = {},
+  ): Promise<EmailConnector> {
     return this.request({
       path: `/system/emailConnectors/${id}`,
       method: 'get',
@@ -1547,7 +1614,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemEmailConnectorsByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<EmailConnectorInfo> = {},
   ): Promise<EmailConnectorInfo> {
     return this.request({
       path: `/system/emailConnectors/${id}/info`,
@@ -1558,7 +1625,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemEmailConnectorsByParentIdParsingStyles(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<EmailConnectorParsingStyle> = {},
   ): Promise<Array<EmailConnectorParsingStyle>> {
     return this.request({
       path: `/system/emailConnectors/${parentId}/parsingStyles`,
@@ -1581,7 +1648,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemEmailConnectorsByParentIdParsingStylesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<EmailConnectorParsingStyle> = {},
   ): Promise<EmailConnectorParsingStyle> {
     return this.request({
       path: `/system/emailConnectors/${parentId}/parsingStyles/${id}`,
@@ -1626,7 +1693,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemEmailConnectorsByParentIdParsingStylesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/emailConnectors/${parentId}/parsingStyles/count`,
@@ -1635,7 +1702,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemEmailConnectorsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemEmailConnectorsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/emailConnectors/count`,
       method: 'get',
@@ -1643,7 +1710,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemEmailConnectorsInfo(params: CommonParameters = {}): Promise<Array<EmailConnectorInfo>> {
+  getSystemEmailConnectorsInfo(
+    params: CommonParameters<EmailConnectorInfo> = {},
+  ): Promise<Array<EmailConnectorInfo>> {
     return this.request({
       path: `/system/emailConnectors/info`,
       method: 'get',
@@ -1651,7 +1720,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemEmailConnectorsInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemEmailConnectorsInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/emailConnectors/info/count`,
       method: 'get',
@@ -1659,7 +1728,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemEmailExclusions(params: CommonParameters = {}): Promise<Array<EmailExclusion>> {
+  getSystemEmailExclusions(
+    params: CommonParameters<EmailExclusion> = {},
+  ): Promise<Array<EmailExclusion>> {
     return this.request({
       path: `/system/emailExclusions`,
       method: 'get',
@@ -1675,7 +1746,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemEmailExclusionsById(id: number, params: CommonParameters = {}): Promise<EmailExclusion> {
+  getSystemEmailExclusionsById(
+    id: number,
+    params: CommonParameters<EmailExclusion> = {},
+  ): Promise<EmailExclusion> {
     return this.request({
       path: `/system/emailExclusions/${id}`,
       method: 'get',
@@ -1712,7 +1786,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemEmailExclusionsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemEmailExclusionsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/emailExclusions/count`,
       method: 'get',
@@ -1720,7 +1794,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemEmailTokens(params: CommonParameters = {}): Promise<Array<EmailToken>> {
+  getSystemEmailTokens(params: CommonParameters<EmailToken> = {}): Promise<Array<EmailToken>> {
     return this.request({
       path: `/system/emailTokens`,
       method: 'get',
@@ -1728,7 +1802,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemEmailTokensById(id: number, params: CommonParameters = {}): Promise<EmailToken> {
+  getSystemEmailTokensById(
+    id: number,
+    params: CommonParameters<EmailToken> = {},
+  ): Promise<EmailToken> {
     return this.request({
       path: `/system/emailTokens/${id}`,
       method: 'get',
@@ -1736,7 +1813,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemEmailTokensCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemEmailTokensCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/emailTokens/count`,
       method: 'get',
@@ -1744,7 +1821,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemEPayConfigurations(params: CommonParameters = {}): Promise<Array<EPayConfiguration>> {
+  getSystemEPayConfigurations(
+    params: CommonParameters<EPayConfiguration> = {},
+  ): Promise<Array<EPayConfiguration>> {
     return this.request({
       path: `/system/ePayConfigurations`,
       method: 'get',
@@ -1762,7 +1841,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemEPayConfigurationsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<EPayConfiguration> = {},
   ): Promise<EPayConfiguration> {
     return this.request({
       path: `/system/ePayConfigurations/${id}`,
@@ -1800,7 +1879,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemEPayConfigurationsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemEPayConfigurationsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/ePayConfigurations/count`,
       method: 'get',
@@ -1808,7 +1887,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemExperiments(params: CommonParameters = {}): Promise<Array<Experiment>> {
+  getSystemExperiments(params: CommonParameters<Experiment> = {}): Promise<Array<Experiment>> {
     return this.request({
       path: `/system/experiments`,
       method: 'get',
@@ -1816,7 +1895,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemExperimentsById(id: number, params: CommonParameters = {}): Promise<Experiment> {
+  getSystemExperimentsById(
+    id: number,
+    params: CommonParameters<Experiment> = {},
+  ): Promise<Experiment> {
     return this.request({
       path: `/system/experiments/${id}`,
       method: 'get',
@@ -1824,7 +1906,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemExperimentsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemExperimentsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/experiments/count`,
       method: 'get',
@@ -1832,7 +1914,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemFileuploadsettings(params: CommonParameters = {}): Promise<Array<FileUploadSetting>> {
+  getSystemFileuploadsettings(
+    params: CommonParameters<FileUploadSetting> = {},
+  ): Promise<Array<FileUploadSetting>> {
     return this.request({
       path: `/system/fileuploadsettings/`,
       method: 'get',
@@ -1842,7 +1926,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemFileuploadsettingsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<FileUploadSetting> = {},
   ): Promise<FileUploadSetting> {
     return this.request({
       path: `/system/fileuploadsettings/${id}`,
@@ -1873,7 +1957,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemFileuploadsettingsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemFileuploadsettingsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/fileuploadsettings/count`,
       method: 'get',
@@ -1881,7 +1965,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemGoogleemailsetup(params: CommonParameters = {}): Promise<Array<GoogleEmailSetup>> {
+  getSystemGoogleemailsetup(
+    params: CommonParameters<GoogleEmailSetup> = {},
+  ): Promise<Array<GoogleEmailSetup>> {
     return this.request({
       path: `/system/googleemailsetup/`,
       method: 'get',
@@ -1899,7 +1985,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemGoogleemailsetupById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<GoogleEmailSetup> = {},
   ): Promise<GoogleEmailSetup> {
     return this.request({
       path: `/system/googleemailsetup/${id}`,
@@ -1944,7 +2030,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemGoogleemailsetupCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemGoogleemailsetupCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/googleemailsetup/count`,
       method: 'get',
@@ -1952,7 +2038,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemImaps(params: CommonParameters = {}): Promise<Array<Imap>> {
+  getSystemImaps(params: CommonParameters<Imap> = {}): Promise<Array<Imap>> {
     return this.request({
       path: `/system/imaps`,
       method: 'get',
@@ -1968,7 +2054,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemImapsById(id: number, params: CommonParameters = {}): Promise<Imap> {
+  getSystemImapsById(id: number, params: CommonParameters<Imap> = {}): Promise<Imap> {
     return this.request({
       path: `/system/imaps/${id}`,
       method: 'get',
@@ -1999,7 +2085,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemImapsByIdInfo(id: number, params: CommonParameters = {}): Promise<ImapInfo> {
+  getSystemImapsByIdInfo(id: number, params: CommonParameters<ImapInfo> = {}): Promise<ImapInfo> {
     return this.request({
       path: `/system/imaps/${id}/info`,
       method: 'get',
@@ -2007,7 +2093,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemImapsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemImapsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/imaps/count`,
       method: 'get',
@@ -2015,7 +2101,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemImapsInfo(params: CommonParameters = {}): Promise<Array<ImapInfo>> {
+  getSystemImapsInfo(params: CommonParameters<ImapInfo> = {}): Promise<Array<ImapInfo>> {
     return this.request({
       path: `/system/imaps/info`,
       method: 'get',
@@ -2023,7 +2109,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemImapsInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemImapsInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/imaps/info/count`,
       method: 'get',
@@ -2038,7 +2124,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInfo(params: CommonParameters = {}): Promise<Info> {
+  getSystemInfo(params: CommonParameters<Info> = {}): Promise<Info> {
     return this.request({
       path: `/system/info`,
       method: 'get',
@@ -2047,7 +2133,7 @@ export class SystemAPI extends ManageBaseAPI {
   }
 
   getSystemInfoDepartmentlocations(
-    params: CommonParameters = {},
+    params: CommonParameters<DepartmentLocationInfo> = {},
   ): Promise<Array<DepartmentLocationInfo>> {
     return this.request({
       path: `/system/info/departmentlocations`,
@@ -2058,7 +2144,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemInfoDepartmentlocationsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<DepartmentLocationInfo> = {},
   ): Promise<DepartmentLocationInfo> {
     return this.request({
       path: `/system/info/departmentlocations/${id}`,
@@ -2067,7 +2153,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInfoDepartmentlocationsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemInfoDepartmentlocationsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/info/departmentlocations/count`,
       method: 'get',
@@ -2075,7 +2161,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInfoDepartments(params: CommonParameters = {}): Promise<Array<DepartmentInfo>> {
+  getSystemInfoDepartments(
+    params: CommonParameters<DepartmentInfo> = {},
+  ): Promise<Array<DepartmentInfo>> {
     return this.request({
       path: `/system/info/departments`,
       method: 'get',
@@ -2083,7 +2171,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInfoDepartmentsById(id: number, params: CommonParameters = {}): Promise<DepartmentInfo> {
+  getSystemInfoDepartmentsById(
+    id: number,
+    params: CommonParameters<DepartmentInfo> = {},
+  ): Promise<DepartmentInfo> {
     return this.request({
       path: `/system/info/departments/${id}`,
       method: 'get',
@@ -2091,7 +2182,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInfoDepartmentsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemInfoDepartmentsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/info/departments/count`,
       method: 'get',
@@ -2099,7 +2190,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInfoLinks(params: CommonParameters = {}): Promise<Array<LinkInfo>> {
+  getSystemInfoLinks(params: CommonParameters<LinkInfo> = {}): Promise<Array<LinkInfo>> {
     return this.request({
       path: `/system/info/links`,
       method: 'get',
@@ -2107,7 +2198,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInfoLinksById(id: number, params: CommonParameters = {}): Promise<LinkInfo> {
+  getSystemInfoLinksById(id: number, params: CommonParameters<LinkInfo> = {}): Promise<LinkInfo> {
     return this.request({
       path: `/system/info/links/${id}`,
       method: 'get',
@@ -2126,7 +2217,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInfoLinksCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemInfoLinksCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/info/links/count`,
       method: 'get',
@@ -2134,7 +2225,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInfoLocales(params: CommonParameters = {}): Promise<Array<LocaleInfo>> {
+  getSystemInfoLocales(params: CommonParameters<LocaleInfo> = {}): Promise<Array<LocaleInfo>> {
     return this.request({
       path: `/system/info/locales`,
       method: 'get',
@@ -2142,7 +2233,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInfoLocalesById(id: number, params: CommonParameters = {}): Promise<LocaleInfo> {
+  getSystemInfoLocalesById(
+    id: number,
+    params: CommonParameters<LocaleInfo> = {},
+  ): Promise<LocaleInfo> {
     return this.request({
       path: `/system/info/locales/${id}`,
       method: 'get',
@@ -2150,7 +2244,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInfoLocalesCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemInfoLocalesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/info/locales/count`,
       method: 'get',
@@ -2158,7 +2252,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInfoLocations(params: CommonParameters = {}): Promise<Array<LocationInfo>> {
+  getSystemInfoLocations(
+    params: CommonParameters<LocationInfo> = {},
+  ): Promise<Array<LocationInfo>> {
     return this.request({
       path: `/system/info/locations`,
       method: 'get',
@@ -2166,7 +2262,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInfoLocationsById(id: number, params: CommonParameters = {}): Promise<LocationInfo> {
+  getSystemInfoLocationsById(
+    id: number,
+    params: CommonParameters<LocationInfo> = {},
+  ): Promise<LocationInfo> {
     return this.request({
       path: `/system/info/locations/${id}`,
       method: 'get',
@@ -2174,7 +2273,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInfoLocationsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemInfoLocationsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/info/locations/count`,
       method: 'get',
@@ -2182,7 +2281,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInfoMembers(params: CommonParameters = {}): Promise<Array<MemberInfo>> {
+  getSystemInfoMembers(params: CommonParameters<MemberInfo> = {}): Promise<Array<MemberInfo>> {
     return this.request({
       path: `/system/info/members`,
       method: 'get',
@@ -2190,7 +2289,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInfoMembersById(id: number, params: CommonParameters = {}): Promise<MemberInfo> {
+  getSystemInfoMembersById(
+    id: number,
+    params: CommonParameters<MemberInfo> = {},
+  ): Promise<MemberInfo> {
     return this.request({
       path: `/system/info/members/${id}`,
       method: 'get',
@@ -2199,7 +2301,7 @@ export class SystemAPI extends ManageBaseAPI {
   }
 
   getSystemInfoMembersmemberIdentifierregextypes(
-    params: CommonParameters = {},
+    params: CommonParameters<MemberInfo> = {},
   ): Promise<MemberInfo> {
     return this.request({
       path: `/system/info/members/{memberIdentifier:regex(^(types. |(`,
@@ -2208,7 +2310,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInfoMembersCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemInfoMembersCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/info/members/count`,
       method: 'get',
@@ -2216,7 +2318,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInfoPersonas(params: CommonParameters = {}): Promise<Array<PersonasInfo>> {
+  getSystemInfoPersonas(params: CommonParameters<PersonasInfo> = {}): Promise<Array<PersonasInfo>> {
     return this.request({
       path: `/system/info/personas`,
       method: 'get',
@@ -2224,7 +2326,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInfoPersonasById(id: number, params: CommonParameters = {}): Promise<PersonasInfo> {
+  getSystemInfoPersonasById(
+    id: number,
+    params: CommonParameters<PersonasInfo> = {},
+  ): Promise<PersonasInfo> {
     return this.request({
       path: `/system/info/personas/${id}`,
       method: 'get',
@@ -2232,7 +2337,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInfoPersonasCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemInfoPersonasCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/info/personas/count`,
       method: 'get',
@@ -2240,7 +2345,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInfoStandardNotes(params: CommonParameters = {}): Promise<Array<StandardNoteInfo>> {
+  getSystemInfoStandardNotes(
+    params: CommonParameters<StandardNoteInfo> = {},
+  ): Promise<Array<StandardNoteInfo>> {
     return this.request({
       path: `/system/info/standardNotes`,
       method: 'get',
@@ -2250,7 +2357,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemInfoStandardNotesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<StandardNoteInfo> = {},
   ): Promise<StandardNoteInfo> {
     return this.request({
       path: `/system/info/standardNotes/${id}`,
@@ -2259,7 +2366,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInfoStandardNotesCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemInfoStandardNotesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/info/standardNotes/count`,
       method: 'get',
@@ -2267,7 +2374,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInOutBoards(params: CommonParameters = {}): Promise<Array<InOutBoard>> {
+  getSystemInOutBoards(params: CommonParameters<InOutBoard> = {}): Promise<Array<InOutBoard>> {
     return this.request({
       path: `/system/inOutBoards`,
       method: 'get',
@@ -2283,7 +2390,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInOutBoardsById(id: number, params: CommonParameters = {}): Promise<InOutBoard> {
+  getSystemInOutBoardsById(
+    id: number,
+    params: CommonParameters<InOutBoard> = {},
+  ): Promise<InOutBoard> {
     return this.request({
       path: `/system/inOutBoards/${id}`,
       method: 'get',
@@ -2317,7 +2427,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInOutBoardsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemInOutBoardsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/inOutBoards/count`,
       method: 'get',
@@ -2325,7 +2435,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInOutTypes(params: CommonParameters = {}): Promise<Array<InOutType>> {
+  getSystemInOutTypes(params: CommonParameters<InOutType> = {}): Promise<Array<InOutType>> {
     return this.request({
       path: `/system/inOutTypes`,
       method: 'get',
@@ -2341,7 +2451,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInOutTypesById(id: number, params: CommonParameters = {}): Promise<InOutType> {
+  getSystemInOutTypesById(
+    id: number,
+    params: CommonParameters<InOutType> = {},
+  ): Promise<InOutType> {
     return this.request({
       path: `/system/inOutTypes/${id}`,
       method: 'get',
@@ -2375,7 +2488,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInOutTypesByIdInfo(id: number, params: CommonParameters = {}): Promise<InOutTypeInfo> {
+  getSystemInOutTypesByIdInfo(
+    id: number,
+    params: CommonParameters<InOutTypeInfo> = {},
+  ): Promise<InOutTypeInfo> {
     return this.request({
       path: `/system/inOutTypes/${id}/info`,
       method: 'get',
@@ -2383,7 +2499,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInOutTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemInOutTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/inOutTypes/count`,
       method: 'get',
@@ -2391,7 +2507,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInOutTypesCountInfo(params: CommonParameters = {}): Promise<Count> {
+  getSystemInOutTypesCountInfo(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/inOutTypes/count/info`,
       method: 'get',
@@ -2399,7 +2515,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemInOutTypesInfo(params: CommonParameters = {}): Promise<Array<InOutTypeInfo>> {
+  getSystemInOutTypesInfo(
+    params: CommonParameters<InOutTypeInfo> = {},
+  ): Promise<Array<InOutTypeInfo>> {
     return this.request({
       path: `/system/inOutTypes/info`,
       method: 'get',
@@ -2407,7 +2525,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemIntegratorlogins(params: CommonParameters = {}): Promise<Array<IntegratorLogin>> {
+  getSystemIntegratorlogins(
+    params: CommonParameters<IntegratorLogin> = {},
+  ): Promise<Array<IntegratorLogin>> {
     return this.request({
       path: `/system/integratorlogins`,
       method: 'get',
@@ -2425,7 +2545,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemIntegratorloginsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<IntegratorLogin> = {},
   ): Promise<IntegratorLogin> {
     return this.request({
       path: `/system/integratorlogins/${id}`,
@@ -2463,7 +2583,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemIntegratorloginsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemIntegratorloginsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/integratorlogins/count`,
       method: 'get',
@@ -2471,7 +2591,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemIntegratorTags(params: CommonParameters = {}): Promise<Array<IntegratorTag>> {
+  getSystemIntegratorTags(
+    params: CommonParameters<IntegratorTag> = {},
+  ): Promise<Array<IntegratorTag>> {
     return this.request({
       path: `/system/integratorTags`,
       method: 'get',
@@ -2487,7 +2609,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemIntegratorTagsById(id: number, params: CommonParameters = {}): Promise<IntegratorTag> {
+  getSystemIntegratorTagsById(
+    id: number,
+    params: CommonParameters<IntegratorTag> = {},
+  ): Promise<IntegratorTag> {
     return this.request({
       path: `/system/integratorTags/${id}`,
       method: 'get',
@@ -2521,7 +2646,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemIntegratorTagsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemIntegratorTagsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/integratorTags/count`,
       method: 'get',
@@ -2529,7 +2654,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemKpiCategories(params: CommonParameters = {}): Promise<Array<KPICategory>> {
+  getSystemKpiCategories(params: CommonParameters<KPICategory> = {}): Promise<Array<KPICategory>> {
     return this.request({
       path: `/system/kpiCategories`,
       method: 'get',
@@ -2537,7 +2662,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemKpiCategoriesById(id: number, params: CommonParameters = {}): Promise<KPICategory> {
+  getSystemKpiCategoriesById(
+    id: number,
+    params: CommonParameters<KPICategory> = {},
+  ): Promise<KPICategory> {
     return this.request({
       path: `/system/kpiCategories/${id}`,
       method: 'get',
@@ -2545,7 +2673,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemKpiCategoriesCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemKpiCategoriesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/kpiCategories/count`,
       method: 'get',
@@ -2553,7 +2681,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemKpis(params: CommonParameters = {}): Promise<Array<KPI>> {
+  getSystemKpis(params: CommonParameters<KPI> = {}): Promise<Array<KPI>> {
     return this.request({
       path: `/system/kpis`,
       method: 'get',
@@ -2561,7 +2689,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemKpisById(id: number, params: CommonParameters = {}): Promise<KPI> {
+  getSystemKpisById(id: number, params: CommonParameters<KPI> = {}): Promise<KPI> {
     return this.request({
       path: `/system/kpis/${id}`,
       method: 'get',
@@ -2569,7 +2697,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemKpisCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemKpisCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/kpis/count`,
       method: 'get',
@@ -2577,7 +2705,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemLdapConfigurations(params: CommonParameters = {}): Promise<Array<LdapConfiguration>> {
+  getSystemLdapConfigurations(
+    params: CommonParameters<LdapConfiguration> = {},
+  ): Promise<Array<LdapConfiguration>> {
     return this.request({
       path: `/system/ldapConfigurations`,
       method: 'get',
@@ -2595,7 +2725,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemLdapConfigurationsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<LdapConfiguration> = {},
   ): Promise<LdapConfiguration> {
     return this.request({
       path: `/system/ldapConfigurations/${id}`,
@@ -2635,7 +2765,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemLdapConfigurationsByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<LdapConfigurationInfo> = {},
   ): Promise<LdapConfigurationInfo> {
     return this.request({
       path: `/system/ldapConfigurations/${id}/info`,
@@ -2644,7 +2774,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemLdapConfigurationsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemLdapConfigurationsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/ldapConfigurations/count`,
       method: 'get',
@@ -2653,7 +2783,7 @@ export class SystemAPI extends ManageBaseAPI {
   }
 
   getSystemLdapConfigurationsInfo(
-    params: CommonParameters = {},
+    params: CommonParameters<LdapConfigurationInfo> = {},
   ): Promise<Array<LdapConfigurationInfo>> {
     return this.request({
       path: `/system/ldapConfigurations/info`,
@@ -2662,7 +2792,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemLdapConfigurationsInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemLdapConfigurationsInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/ldapConfigurations/info/count`,
       method: 'get',
@@ -2680,7 +2810,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemLinks(params: CommonParameters = {}): Promise<Array<Link>> {
+  getSystemLinks(params: CommonParameters<Link> = {}): Promise<Array<Link>> {
     return this.request({
       path: `/system/links`,
       method: 'get',
@@ -2696,7 +2826,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemLinksById(id: number, params: CommonParameters = {}): Promise<Link> {
+  getSystemLinksById(id: number, params: CommonParameters<Link> = {}): Promise<Link> {
     return this.request({
       path: `/system/links/${id}`,
       method: 'get',
@@ -2727,7 +2857,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemLinksCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemLinksCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/links/count`,
       method: 'get',
@@ -2735,7 +2865,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemLocations(params: CommonParameters = {}): Promise<Array<Location>> {
+  getSystemLocations(params: CommonParameters<Location> = {}): Promise<Array<Location>> {
     return this.request({
       path: `/system/locations`,
       method: 'get',
@@ -2751,7 +2881,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemLocationsById(id: number, params: CommonParameters = {}): Promise<Location> {
+  getSystemLocationsById(id: number, params: CommonParameters<Location> = {}): Promise<Location> {
     return this.request({
       path: `/system/locations/${id}`,
       method: 'get',
@@ -2782,7 +2912,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemLocationsByIdUsages(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getSystemLocationsByIdUsages(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/system/locations/${id}/usages`,
       method: 'get',
@@ -2792,7 +2925,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemLocationsByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/system/locations/${id}/usages/list`,
@@ -2803,7 +2936,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemLocationsByParentIdDepartments(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<LocationDepartment> = {},
   ): Promise<Array<LocationDepartment>> {
     return this.request({
       path: `/system/locations/${parentId}/departments`,
@@ -2815,7 +2948,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemLocationsByParentIdDepartmentsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<LocationDepartment> = {},
   ): Promise<LocationDepartment> {
     return this.request({
       path: `/system/locations/${parentId}/departments/${id}`,
@@ -2826,7 +2959,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemLocationsByParentIdDepartmentsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/locations/${parentId}/departments/count`,
@@ -2837,7 +2970,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemLocationsByParentIdWorkRoles(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<LocationWorkRole> = {},
   ): Promise<Array<LocationWorkRole>> {
     return this.request({
       path: `/system/locations/${parentId}/workRoles`,
@@ -2849,7 +2982,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemLocationsByParentIdWorkRolesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<LocationWorkRole> = {},
   ): Promise<LocationWorkRole> {
     return this.request({
       path: `/system/locations/${parentId}/workRoles/${id}`,
@@ -2860,7 +2993,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemLocationsByParentIdWorkRolesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/locations/${parentId}/workRoles/count`,
@@ -2869,7 +3002,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemLocationsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemLocationsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/locations/count`,
       method: 'get',
@@ -2879,7 +3012,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemM365contactsyncByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<M365ContactSyncInfo> = {},
   ): Promise<M365ContactSyncInfo> {
     return this.request({
       path: `/system/m365contactsync/${id}/info`,
@@ -2888,7 +3021,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemM365contactsyncInfo(params: CommonParameters = {}): Promise<Array<M365ContactSyncInfo>> {
+  getSystemM365contactsyncInfo(
+    params: CommonParameters<M365ContactSyncInfo> = {},
+  ): Promise<Array<M365ContactSyncInfo>> {
     return this.request({
       path: `/system/m365contactsync/info`,
       method: 'get',
@@ -2896,7 +3031,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemM365contactsyncInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemM365contactsyncInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/m365contactsync/info/count`,
       method: 'get',
@@ -2905,7 +3040,7 @@ export class SystemAPI extends ManageBaseAPI {
   }
 
   getSystemManagementNetworkSecurities(
-    params: CommonParameters = {},
+    params: CommonParameters<ManagementNetworkSecurity> = {},
   ): Promise<Array<ManagementNetworkSecurity>> {
     return this.request({
       path: `/system/managementNetworkSecurities`,
@@ -2926,7 +3061,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemManagementNetworkSecuritiesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ManagementNetworkSecurity> = {},
   ): Promise<ManagementNetworkSecurity> {
     return this.request({
       path: `/system/managementNetworkSecurities/${id}`,
@@ -2966,7 +3101,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemManagementNetworkSecuritiesByIdTestCredentials(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<SuccessResponse> = {},
   ): Promise<SuccessResponse> {
     return this.request({
       path: `/system/managementNetworkSecurities/${id}/testCredentials`,
@@ -2975,7 +3110,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemManagementNetworkSecuritiesCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemManagementNetworkSecuritiesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/managementNetworkSecurities/count`,
       method: 'get',
@@ -2985,7 +3120,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMarketplaceimportGetdefinitionById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MarketplaceImport> = {},
   ): Promise<MarketplaceImport> {
     return this.request({
       path: `/system/marketplaceimport/getdefinition/${id}`,
@@ -3004,7 +3139,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMembers(params: CommonParameters = {}): Promise<Array<Member>> {
+  getSystemMembers(params: CommonParameters<Member> = {}): Promise<Array<Member>> {
     return this.request({
       path: `/system/members`,
       method: 'get',
@@ -3020,7 +3155,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMembersById(id: number, params: CommonParameters = {}): Promise<Member> {
+  getSystemMembersById(id: number, params: CommonParameters<Member> = {}): Promise<Member> {
     return this.request({
       path: `/system/members/${id}`,
       method: 'get',
@@ -3057,7 +3192,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMembersByIdImage(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<OctetStreamResponse> = {},
   ): Promise<OctetStreamResponse> {
     return this.request({
       path: `/system/members/${id}/image`,
@@ -3096,7 +3231,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMembersByIdUsages(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getSystemMembersByIdUsages(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/system/members/${id}/usages`,
       method: 'get',
@@ -3104,7 +3242,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMembersByIdUsagesList(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getSystemMembersByIdUsagesList(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/system/members/${id}/usages/list`,
       method: 'get',
@@ -3112,7 +3253,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMembersmemberIdentifierregextypes(params: CommonParameters = {}): Promise<Member> {
+  getSystemMembersmemberIdentifierregextypes(
+    params: CommonParameters<Member> = {},
+  ): Promise<Member> {
     return this.request({
       path: `/system/members/{memberIdentifier:regex(^(types. |(`,
       method: 'get',
@@ -3130,7 +3273,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMembersByParentIdAccruals(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MemberAccrual> = {},
   ): Promise<Array<MemberAccrual>> {
     return this.request({
       path: `/system/members/${parentId}/accruals`,
@@ -3153,7 +3296,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemMembersByParentIdAccrualsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MemberAccrual> = {},
   ): Promise<MemberAccrual> {
     return this.request({
       path: `/system/members/${parentId}/accruals/${id}`,
@@ -3198,7 +3341,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMembersByParentIdAccrualsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/members/${parentId}/accruals/count`,
@@ -3209,7 +3352,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMembersByParentIdCertifications(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MemberCertification> = {},
   ): Promise<Array<MemberCertification>> {
     return this.request({
       path: `/system/members/${parentId}/certifications`,
@@ -3232,7 +3375,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemMembersByParentIdCertificationsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MemberCertification> = {},
   ): Promise<MemberCertification> {
     return this.request({
       path: `/system/members/${parentId}/certifications/${id}`,
@@ -3277,7 +3420,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMembersByParentIdCertificationsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/members/${parentId}/certifications/count`,
@@ -3288,7 +3431,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMembersByParentIdDelegations(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MemberDelegation> = {},
   ): Promise<Array<MemberDelegation>> {
     return this.request({
       path: `/system/members/${parentId}/delegations`,
@@ -3311,7 +3454,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemMembersByParentIdDelegationsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MemberDelegation> = {},
   ): Promise<MemberDelegation> {
     return this.request({
       path: `/system/members/${parentId}/delegations/${id}`,
@@ -3356,7 +3499,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMembersByParentIdDelegationsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/members/${parentId}/delegations/count`,
@@ -3367,7 +3510,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMembersByParentIdManagedDeviceAccounts(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ManagedDeviceAccount> = {},
   ): Promise<Array<ManagedDeviceAccount>> {
     return this.request({
       path: `/system/members/${parentId}/managedDeviceAccounts`,
@@ -3400,7 +3543,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMembersByParentIdMycertifications(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MemberCertification> = {},
   ): Promise<Array<MemberCertification>> {
     return this.request({
       path: `/system/members/${parentId}/mycertifications`,
@@ -3423,7 +3566,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemMembersByParentIdMycertificationsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MemberCertification> = {},
   ): Promise<MemberCertification> {
     return this.request({
       path: `/system/members/${parentId}/mycertifications/${id}`,
@@ -3468,7 +3611,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMembersByParentIdMycertificationsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/members/${parentId}/mycertifications/count`,
@@ -3479,7 +3622,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMembersByParentIdNotificationSettings(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MemberNotificationSetting> = {},
   ): Promise<Array<MemberNotificationSetting>> {
     return this.request({
       path: `/system/members/${parentId}/notificationSettings`,
@@ -3502,7 +3645,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemMembersByParentIdNotificationSettingsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MemberNotificationSetting> = {},
   ): Promise<MemberNotificationSetting> {
     return this.request({
       path: `/system/members/${parentId}/notificationSettings/${id}`,
@@ -3547,7 +3690,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMembersByParentIdNotificationSettingsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/members/${parentId}/notificationSettings/count`,
@@ -3558,7 +3701,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMembersByParentIdPersonas(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MemberPersona> = {},
   ): Promise<Array<MemberPersona>> {
     return this.request({
       path: `/system/members/${parentId}/personas`,
@@ -3581,7 +3724,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemMembersByParentIdPersonasById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MemberPersona> = {},
   ): Promise<MemberPersona> {
     return this.request({
       path: `/system/members/${parentId}/personas/${id}`,
@@ -3626,7 +3769,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMembersByParentIdPersonasCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/members/${parentId}/personas/count`,
@@ -3637,7 +3780,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMembersByParentIdSkills(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MemberSkill> = {},
   ): Promise<Array<MemberSkill>> {
     return this.request({
       path: `/system/members/${parentId}/skills`,
@@ -3660,7 +3803,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemMembersByParentIdSkillsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MemberSkill> = {},
   ): Promise<MemberSkill> {
     return this.request({
       path: `/system/members/${parentId}/skills/${id}`,
@@ -3705,7 +3848,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMembersByParentIdSkillsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/members/${parentId}/skills/count`,
@@ -3721,7 +3864,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMembersCalendarsync(params: CommonParameters = {}): Promise<Array<MemberForCalSync>> {
+  getSystemMembersCalendarsync(
+    params: CommonParameters<MemberForCalSync> = {},
+  ): Promise<Array<MemberForCalSync>> {
     return this.request({
       path: `/system/members/calendarsync`,
       method: 'get',
@@ -3729,7 +3874,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMembersCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemMembersCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/members/count`,
       method: 'get',
@@ -3737,7 +3882,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMembersTypes(params: CommonParameters = {}): Promise<Array<MemberType>> {
+  getSystemMembersTypes(params: CommonParameters<MemberType> = {}): Promise<Array<MemberType>> {
     return this.request({
       path: `/system/members/types`,
       method: 'get',
@@ -3753,7 +3898,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMembersTypesById(id: number, params: CommonParameters = {}): Promise<MemberType> {
+  getSystemMembersTypesById(
+    id: number,
+    params: CommonParameters<MemberType> = {},
+  ): Promise<MemberType> {
     return this.request({
       path: `/system/members/types/${id}`,
       method: 'get',
@@ -3789,7 +3937,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMembersTypesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MemberTypeInfo> = {},
   ): Promise<MemberTypeInfo> {
     return this.request({
       path: `/system/members/types/${id}/info`,
@@ -3798,7 +3946,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMembersTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemMembersTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/members/types/count`,
       method: 'get',
@@ -3806,7 +3954,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMembersTypesInfo(params: CommonParameters = {}): Promise<Array<MemberTypeInfo>> {
+  getSystemMembersTypesInfo(
+    params: CommonParameters<MemberTypeInfo> = {},
+  ): Promise<Array<MemberTypeInfo>> {
     return this.request({
       path: `/system/members/types/info`,
       method: 'get',
@@ -3814,7 +3964,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMembersTypesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemMembersTypesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/members/types/info/count`,
       method: 'get',
@@ -3822,7 +3972,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMembersWithSso(params: CommonParameters = {}): Promise<Array<Member>> {
+  getSystemMembersWithSso(params: CommonParameters<Member> = {}): Promise<Array<Member>> {
     return this.request({
       path: `/system/members/withSso`,
       method: 'get',
@@ -3830,7 +3980,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMembertemplates(params: CommonParameters = {}): Promise<Array<MemberTemplate>> {
+  getSystemMembertemplates(
+    params: CommonParameters<MemberTemplate> = {},
+  ): Promise<Array<MemberTemplate>> {
     return this.request({
       path: `/system/membertemplates/`,
       method: 'get',
@@ -3846,7 +3998,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMembertemplatesById(id: number, params: CommonParameters = {}): Promise<MemberTemplate> {
+  getSystemMembertemplatesById(
+    id: number,
+    params: CommonParameters<MemberTemplate> = {},
+  ): Promise<MemberTemplate> {
     return this.request({
       path: `/system/membertemplates/${id}`,
       method: 'get',
@@ -3865,7 +4020,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMembertemplatesCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemMembertemplatesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/membertemplates/count`,
       method: 'get',
@@ -3873,7 +4028,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMenuentries(params: CommonParameters = {}): Promise<Array<MenuEntry>> {
+  getSystemMenuentries(params: CommonParameters<MenuEntry> = {}): Promise<Array<MenuEntry>> {
     return this.request({
       path: `/system/menuentries`,
       method: 'get',
@@ -3889,7 +4044,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMenuentriesById(id: number, params: CommonParameters = {}): Promise<MenuEntry> {
+  getSystemMenuentriesById(
+    id: number,
+    params: CommonParameters<MenuEntry> = {},
+  ): Promise<MenuEntry> {
     return this.request({
       path: `/system/menuentries/${id}`,
       method: 'get',
@@ -3925,7 +4083,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMenuentriesByIdImage(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<OctetStreamResponse> = {},
   ): Promise<OctetStreamResponse> {
     return this.request({
       path: `/system/menuentries/${id}/image`,
@@ -3943,7 +4101,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMenuEntriesByParentIdLocations(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MenuEntryLocation> = {},
   ): Promise<Array<MenuEntryLocation>> {
     return this.request({
       path: `/system/menuEntries/${parentId}/locations`,
@@ -3966,7 +4124,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemMenuEntriesByParentIdLocationsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MenuEntryLocation> = {},
   ): Promise<MenuEntryLocation> {
     return this.request({
       path: `/system/menuEntries/${parentId}/locations/${id}`,
@@ -3987,7 +4145,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMenuEntriesByParentIdLocationsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/menuEntries/${parentId}/locations/count`,
@@ -3996,7 +4154,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMenuentriesCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemMenuentriesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/menuentries/count`,
       method: 'get',
@@ -4004,7 +4162,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMyAccountById(id: number, params: CommonParameters = {}): Promise<MyAccount> {
+  getSystemMyAccountById(id: number, params: CommonParameters<MyAccount> = {}): Promise<MyAccount> {
     return this.request({
       path: `/system/myAccount/${id}`,
       method: 'get',
@@ -4030,7 +4188,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMyAccountByParentIdDelegations(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MemberDelegation> = {},
   ): Promise<Array<MemberDelegation>> {
     return this.request({
       path: `/system/myAccount/${parentId}/delegations`,
@@ -4053,7 +4211,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemMyAccountByParentIdDelegationsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MemberDelegation> = {},
   ): Promise<MemberDelegation> {
     return this.request({
       path: `/system/myAccount/${parentId}/delegations/${id}`,
@@ -4098,7 +4256,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMyAccountByParentIdDelegationsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/myAccount/${parentId}/delegations/count`,
@@ -4109,7 +4267,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMyAccountByParentIdSkills(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MemberSkill> = {},
   ): Promise<Array<MemberSkill>> {
     return this.request({
       path: `/system/myAccount/${parentId}/skills`,
@@ -4132,7 +4290,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemMyAccountByParentIdSkillsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<MemberSkill> = {},
   ): Promise<MemberSkill> {
     return this.request({
       path: `/system/myAccount/${parentId}/skills/${id}`,
@@ -4177,7 +4335,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMyAccountByParentIdSkillsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/myAccount/${parentId}/skills/count`,
@@ -4187,7 +4345,7 @@ export class SystemAPI extends ManageBaseAPI {
   }
 
   getSystemMyCompanyCorporateStructure(
-    params: CommonParameters = {},
+    params: CommonParameters<CorporateStructure> = {},
   ): Promise<Array<CorporateStructure>> {
     return this.request({
       path: `/system/myCompany/corporateStructure`,
@@ -4198,7 +4356,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMyCompanyCorporateStructureById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CorporateStructure> = {},
   ): Promise<CorporateStructure> {
     return this.request({
       path: `/system/myCompany/corporateStructure/${id}`,
@@ -4231,7 +4389,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMyCompanyCorporateStructureByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CorporateStructureInfo> = {},
   ): Promise<CorporateStructureInfo> {
     return this.request({
       path: `/system/myCompany/corporateStructure/${id}/info`,
@@ -4240,7 +4398,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMyCompanyCorporateStructureCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemMyCompanyCorporateStructureCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/myCompany/corporateStructure/count`,
       method: 'get',
@@ -4249,7 +4407,7 @@ export class SystemAPI extends ManageBaseAPI {
   }
 
   getSystemMyCompanyCorporateStructureInfo(
-    params: CommonParameters = {},
+    params: CommonParameters<CorporateStructureInfo> = {},
   ): Promise<Array<CorporateStructureInfo>> {
     return this.request({
       path: `/system/myCompany/corporateStructure/info`,
@@ -4258,7 +4416,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMyCompanyCorporateStructureInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemMyCompanyCorporateStructureInfoCount(
+    params: CommonParameters<Count> = {},
+  ): Promise<Count> {
     return this.request({
       path: `/system/myCompany/corporateStructure/info/count`,
       method: 'get',
@@ -4267,7 +4427,7 @@ export class SystemAPI extends ManageBaseAPI {
   }
 
   getSystemMyCompanyCorporateStructureLevels(
-    params: CommonParameters = {},
+    params: CommonParameters<CorporateStructureLevel> = {},
   ): Promise<Array<CorporateStructureLevel>> {
     return this.request({
       path: `/system/myCompany/corporateStructureLevels`,
@@ -4278,7 +4438,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMyCompanyCorporateStructureLevelsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<CorporateStructureLevel> = {},
   ): Promise<CorporateStructureLevel> {
     return this.request({
       path: `/system/myCompany/corporateStructureLevels/${id}`,
@@ -4287,7 +4447,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMyCompanyCorporateStructureLevelsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemMyCompanyCorporateStructureLevelsCount(
+    params: CommonParameters<Count> = {},
+  ): Promise<Count> {
     return this.request({
       path: `/system/myCompany/corporateStructureLevels/count`,
       method: 'get',
@@ -4295,7 +4457,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMyCompanyCrm(params: CommonParameters = {}): Promise<Array<Crm>> {
+  getSystemMyCompanyCrm(params: CommonParameters<Crm> = {}): Promise<Array<Crm>> {
     return this.request({
       path: `/system/myCompany/crm`,
       method: 'get',
@@ -4303,7 +4465,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMyCompanyCrmById(id: number, params: CommonParameters = {}): Promise<Crm> {
+  getSystemMyCompanyCrmById(id: number, params: CommonParameters<Crm> = {}): Promise<Crm> {
     return this.request({
       path: `/system/myCompany/crm/${id}`,
       method: 'get',
@@ -4327,7 +4489,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMyCompanyCrmByIdInfo(id: number, params: CommonParameters = {}): Promise<CrmInfo> {
+  getSystemMyCompanyCrmByIdInfo(
+    id: number,
+    params: CommonParameters<CrmInfo> = {},
+  ): Promise<CrmInfo> {
     return this.request({
       path: `/system/myCompany/crm/${id}/info`,
       method: 'get',
@@ -4335,7 +4500,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMyCompanyCrmCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemMyCompanyCrmCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/myCompany/crm/count`,
       method: 'get',
@@ -4343,7 +4508,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMyCompanyCrmInfo(params: CommonParameters = {}): Promise<Array<CrmInfo>> {
+  getSystemMyCompanyCrmInfo(params: CommonParameters<CrmInfo> = {}): Promise<Array<CrmInfo>> {
     return this.request({
       path: `/system/myCompany/crm/info`,
       method: 'get',
@@ -4351,7 +4516,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMyCompanyCrmInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemMyCompanyCrmInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/myCompany/crm/info/count`,
       method: 'get',
@@ -4359,7 +4524,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMycompanyDocuments(params: CommonParameters = {}): Promise<Array<DocumentSetup>> {
+  getSystemMycompanyDocuments(
+    params: CommonParameters<DocumentSetup> = {},
+  ): Promise<Array<DocumentSetup>> {
     return this.request({
       path: `/system/mycompany/documents`,
       method: 'get',
@@ -4369,7 +4536,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMycompanyDocumentsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<DocumentSetup> = {},
   ): Promise<DocumentSetup> {
     return this.request({
       path: `/system/mycompany/documents/${id}`,
@@ -4397,7 +4564,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMycompanyInfoServices(params: CommonParameters = {}): Promise<Array<ServiceInfo>> {
+  getSystemMycompanyInfoServices(
+    params: CommonParameters<ServiceInfo> = {},
+  ): Promise<Array<ServiceInfo>> {
     return this.request({
       path: `/system/mycompany/info/services`,
       method: 'get',
@@ -4407,7 +4576,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMycompanyInfoServicesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ServiceInfo> = {},
   ): Promise<ServiceInfo> {
     return this.request({
       path: `/system/mycompany/info/services/${id}`,
@@ -4416,7 +4585,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMyCompanyOther(params: CommonParameters = {}): Promise<Array<Other>> {
+  getSystemMyCompanyOther(params: CommonParameters<Other> = {}): Promise<Array<Other>> {
     return this.request({
       path: `/system/myCompany/other`,
       method: 'get',
@@ -4424,7 +4593,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMyCompanyOtherById(id: number, params: CommonParameters = {}): Promise<Other> {
+  getSystemMyCompanyOtherById(id: number, params: CommonParameters<Other> = {}): Promise<Other> {
     return this.request({
       path: `/system/myCompany/other/${id}`,
       method: 'get',
@@ -4451,7 +4620,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMyCompanyOtherCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemMyCompanyOtherCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/myCompany/other/count`,
       method: 'get',
@@ -4460,7 +4629,7 @@ export class SystemAPI extends ManageBaseAPI {
   }
 
   getSystemMycompanyReportingServices(
-    params: CommonParameters = {},
+    params: CommonParameters<ReportingService> = {},
   ): Promise<Array<ReportingService>> {
     return this.request({
       path: `/system/mycompany/reportingServices`,
@@ -4471,7 +4640,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMycompanyReportingServicesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ReportingService> = {},
   ): Promise<ReportingService> {
     return this.request({
       path: `/system/mycompany/reportingServices/${id}`,
@@ -4509,7 +4678,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMycompanyServices(params: CommonParameters = {}): Promise<Array<Service>> {
+  getSystemMycompanyServices(params: CommonParameters<Service> = {}): Promise<Array<Service>> {
     return this.request({
       path: `/system/mycompany/services`,
       method: 'get',
@@ -4517,7 +4686,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMycompanyServicesById(id: number, params: CommonParameters = {}): Promise<Service> {
+  getSystemMycompanyServicesById(
+    id: number,
+    params: CommonParameters<Service> = {},
+  ): Promise<Service> {
     return this.request({
       path: `/system/mycompany/services/${id}`,
       method: 'get',
@@ -4544,7 +4716,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMyCompanyTimeExpense(params: CommonParameters = {}): Promise<Array<TimeExpense>> {
+  getSystemMyCompanyTimeExpense(
+    params: CommonParameters<TimeExpense> = {},
+  ): Promise<Array<TimeExpense>> {
     return this.request({
       path: `/system/myCompany/timeExpense`,
       method: 'get',
@@ -4554,7 +4728,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemMyCompanyTimeExpenseById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TimeExpense> = {},
   ): Promise<TimeExpense> {
     return this.request({
       path: `/system/myCompany/timeExpense/${id}`,
@@ -4582,7 +4756,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMyCompanyTimeExpenseCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemMyCompanyTimeExpenseCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/myCompany/timeExpense/count`,
       method: 'get',
@@ -4590,7 +4764,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMyMembers(params: CommonParameters = {}): Promise<MyMember> {
+  getSystemMyMembers(params: CommonParameters<MyMember> = {}): Promise<MyMember> {
     return this.request({
       path: `/system/myMembers`,
       method: 'get',
@@ -4598,7 +4772,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMyMembersInfo(params: CommonParameters = {}): Promise<MyMemberInfo> {
+  getSystemMyMembersInfo(params: CommonParameters<MyMemberInfo> = {}): Promise<MyMemberInfo> {
     return this.request({
       path: `/system/myMembers/info`,
       method: 'get',
@@ -4606,7 +4780,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemMySecurity(params: CommonParameters = {}): Promise<Array<MySecurity>> {
+  getSystemMySecurity(params: CommonParameters<MySecurity> = {}): Promise<Array<MySecurity>> {
     return this.request({
       path: `/system/mySecurity`,
       method: 'get',
@@ -4615,7 +4789,7 @@ export class SystemAPI extends ManageBaseAPI {
   }
 
   getSystemMySecurityCustomizeItems(
-    params: CommonParameters = {},
+    params: CommonParameters<MySecurityCustomizeItem> = {},
   ): Promise<Array<MySecurityCustomizeItem>> {
     return this.request({
       path: `/system/mySecurity/customizeItems/`,
@@ -4625,7 +4799,7 @@ export class SystemAPI extends ManageBaseAPI {
   }
 
   getSystemNotificationRecipients(
-    params: CommonParameters = {},
+    params: CommonParameters<NotificationRecipient> = {},
   ): Promise<Array<NotificationRecipient>> {
     return this.request({
       path: `/system/notificationRecipients`,
@@ -4636,7 +4810,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemNotificationRecipientsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<NotificationRecipient> = {},
   ): Promise<NotificationRecipient> {
     return this.request({
       path: `/system/notificationRecipients/${id}`,
@@ -4645,7 +4819,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemNotificationRecipientsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemNotificationRecipientsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/notificationRecipients/count`,
       method: 'get',
@@ -4655,7 +4829,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemOffice365ApplicationByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Office365EmailApplicationInfo> = {},
   ): Promise<Office365EmailApplicationInfo> {
     return this.request({
       path: `/system/office365/application/${id}/info`,
@@ -4665,7 +4839,7 @@ export class SystemAPI extends ManageBaseAPI {
   }
 
   getSystemOffice365ApplicationInfo(
-    params: CommonParameters = {},
+    params: CommonParameters<Office365EmailApplicationInfo> = {},
   ): Promise<Array<Office365EmailApplicationInfo>> {
     return this.request({
       path: `/system/office365/application/info`,
@@ -4674,7 +4848,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemOffice365ApplicationInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemOffice365ApplicationInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/office365/application/info/count`,
       method: 'get',
@@ -4683,7 +4857,7 @@ export class SystemAPI extends ManageBaseAPI {
   }
 
   getSystemOffice365EmailSetups(
-    params: CommonParameters = {},
+    params: CommonParameters<Office365EmailSetup> = {},
   ): Promise<Array<Office365EmailSetup>> {
     return this.request({
       path: `/system/office365/emailSetups`,
@@ -4702,7 +4876,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemOffice365EmailSetupsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Office365EmailSetup> = {},
   ): Promise<Office365EmailSetup> {
     return this.request({
       path: `/system/office365/emailSetups/${id}`,
@@ -4749,7 +4923,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemOffice365EmailSetupsByIdGetEmails(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<UserEmail> = {},
   ): Promise<Array<UserEmail>> {
     return this.request({
       path: `/system/office365/emailSetups/${id}/getEmails/`,
@@ -4765,7 +4939,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemOffice365EmailSetupsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemOffice365EmailSetupsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/office365/emailSetups/count`,
       method: 'get',
@@ -4774,7 +4948,7 @@ export class SystemAPI extends ManageBaseAPI {
   }
 
   getSystemOnPremiseSearchSetting(
-    params: CommonParameters = {},
+    params: CommonParameters<OnPremiseSearchSetting> = {},
   ): Promise<Array<OnPremiseSearchSetting>> {
     return this.request({
       path: `/system/onPremiseSearchSetting/`,
@@ -4785,7 +4959,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemOnPremiseSearchSettingById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<OnPremiseSearchSetting> = {},
   ): Promise<OnPremiseSearchSetting> {
     return this.request({
       path: `/system/onPremiseSearchSetting/${id}`,
@@ -4816,7 +4990,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemOnPremiseSearchSettingCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemOnPremiseSearchSettingCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/onPremiseSearchSetting/count`,
       method: 'get',
@@ -4824,7 +4998,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemOsgradeweights(params: CommonParameters = {}): Promise<Array<OsGradeWeight>> {
+  getSystemOsgradeweights(
+    params: CommonParameters<OsGradeWeight> = {},
+  ): Promise<Array<OsGradeWeight>> {
     return this.request({
       path: `/system/osgradeweights`,
       method: 'get',
@@ -4832,7 +5008,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemOsgradeweightsById(id: number, params: CommonParameters = {}): Promise<OsGradeWeight> {
+  getSystemOsgradeweightsById(
+    id: number,
+    params: CommonParameters<OsGradeWeight> = {},
+  ): Promise<OsGradeWeight> {
     return this.request({
       path: `/system/osgradeweights/${id}`,
       method: 'get',
@@ -4859,7 +5038,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemOsgradeweightsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemOsgradeweightsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/osgradeweights/count`,
       method: 'get',
@@ -4867,7 +5046,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemParsingTypes(params: CommonParameters = {}): Promise<Array<ParsingType>> {
+  getSystemParsingTypes(params: CommonParameters<ParsingType> = {}): Promise<Array<ParsingType>> {
     return this.request({
       path: `/system/parsingTypes`,
       method: 'get',
@@ -4875,7 +5054,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemParsingTypesById(id: number, params: CommonParameters = {}): Promise<ParsingType> {
+  getSystemParsingTypesById(
+    id: number,
+    params: CommonParameters<ParsingType> = {},
+  ): Promise<ParsingType> {
     return this.request({
       path: `/system/parsingTypes/${id}`,
       method: 'get',
@@ -4883,7 +5065,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemParsingTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemParsingTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/parsingTypes/count`,
       method: 'get',
@@ -4891,7 +5073,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemParsingVariables(params: CommonParameters = {}): Promise<Array<ParsingVariable>> {
+  getSystemParsingVariables(
+    params: CommonParameters<ParsingVariable> = {},
+  ): Promise<Array<ParsingVariable>> {
     return this.request({
       path: `/system/parsingVariables`,
       method: 'get',
@@ -4901,7 +5085,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemParsingVariablesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ParsingVariable> = {},
   ): Promise<ParsingVariable> {
     return this.request({
       path: `/system/parsingVariables/${id}`,
@@ -4910,7 +5094,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemParsingVariablesCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemParsingVariablesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/parsingVariables/count`,
       method: 'get',
@@ -4918,7 +5102,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemPortalReports(params: CommonParameters = {}): Promise<Array<PortalReport>> {
+  getSystemPortalReports(
+    params: CommonParameters<PortalReport> = {},
+  ): Promise<Array<PortalReport>> {
     return this.request({
       path: `/system/portalReports`,
       method: 'get',
@@ -4934,7 +5120,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemPortalReportsById(id: number, params: CommonParameters = {}): Promise<PortalReport> {
+  getSystemPortalReportsById(
+    id: number,
+    params: CommonParameters<PortalReport> = {},
+  ): Promise<PortalReport> {
     return this.request({
       path: `/system/portalReports/${id}`,
       method: 'get',
@@ -4968,7 +5157,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemPortalReportsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemPortalReportsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/portalReports/count`,
       method: 'get',
@@ -4976,7 +5165,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemQuoteLinkSetup(params: CommonParameters = {}): Promise<Array<QuoteLink>> {
+  getSystemQuoteLinkSetup(params: CommonParameters<QuoteLink> = {}): Promise<Array<QuoteLink>> {
     return this.request({
       path: `/system/quoteLinkSetup`,
       method: 'get',
@@ -4992,7 +5181,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemQuoteLinkSetupById(id: number, params: CommonParameters = {}): Promise<QuoteLink> {
+  getSystemQuoteLinkSetupById(
+    id: number,
+    params: CommonParameters<QuoteLink> = {},
+  ): Promise<QuoteLink> {
     return this.request({
       path: `/system/quoteLinkSetup/${id}`,
       method: 'get',
@@ -5026,7 +5218,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemQuoteLinkSetupCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemQuoteLinkSetupCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/quoteLinkSetup/count`,
       method: 'get',
@@ -5034,7 +5226,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemQuoteLinkSetupTestConnection(params: CommonParameters = {}): Promise<SuccessResponse> {
+  getSystemQuoteLinkSetupTestConnection(
+    params: CommonParameters<SuccessResponse> = {},
+  ): Promise<SuccessResponse> {
     return this.request({
       path: `/system/quoteLinkSetup/testConnection`,
       method: 'get',
@@ -5042,7 +5236,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemReportCards(params: CommonParameters = {}): Promise<Array<ReportCard>> {
+  getSystemReportCards(params: CommonParameters<ReportCard> = {}): Promise<Array<ReportCard>> {
     return this.request({
       path: `/system/reportCards`,
       method: 'get',
@@ -5058,7 +5252,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemReportCardsById(id: number, params: CommonParameters = {}): Promise<ReportCard> {
+  getSystemReportCardsById(
+    id: number,
+    params: CommonParameters<ReportCard> = {},
+  ): Promise<ReportCard> {
     return this.request({
       path: `/system/reportCards/${id}`,
       method: 'get',
@@ -5092,7 +5289,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemReportCardsByIdInfo(id: number, params: CommonParameters = {}): Promise<ReportCardInfo> {
+  getSystemReportCardsByIdInfo(
+    id: number,
+    params: CommonParameters<ReportCardInfo> = {},
+  ): Promise<ReportCardInfo> {
     return this.request({
       path: `/system/reportCards/${id}/info`,
       method: 'get',
@@ -5102,7 +5302,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemReportCardsByParentIdDetails(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ReportCardDetail> = {},
   ): Promise<Array<ReportCardDetail>> {
     return this.request({
       path: `/system/reportCards/${parentId}/details`,
@@ -5125,7 +5325,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemReportCardsByParentIdDetailsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ReportCardDetail> = {},
   ): Promise<ReportCardDetail> {
     return this.request({
       path: `/system/reportCards/${parentId}/details/${id}`,
@@ -5170,7 +5370,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemReportCardsByParentIdDetailsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/reportCards/${parentId}/details/count`,
@@ -5179,7 +5379,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemReportCardsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemReportCardsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/reportCards/count`,
       method: 'get',
@@ -5187,7 +5387,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemReportCardsInfo(params: CommonParameters = {}): Promise<Array<ReportCardInfo>> {
+  getSystemReportCardsInfo(
+    params: CommonParameters<ReportCardInfo> = {},
+  ): Promise<Array<ReportCardInfo>> {
     return this.request({
       path: `/system/reportCards/info`,
       method: 'get',
@@ -5195,7 +5397,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemReportCardsInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemReportCardsInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/reportCards/info/count`,
       method: 'get',
@@ -5203,7 +5405,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemReports(params: CommonParameters = {}): Promise<Array<Report>> {
+  getSystemReports(params: CommonParameters<Report> = {}): Promise<Array<Report>> {
     return this.request({
       path: `/system/reports`,
       method: 'get',
@@ -5213,7 +5415,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemReportsByReportName(
     reportName: string,
-    params: CommonParameters = {},
+    params: CommonParameters<ReportDataResponse> = {},
   ): Promise<ReportDataResponse> {
     return this.request({
       path: `/system/reports/${reportName}`,
@@ -5224,7 +5426,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemReportsByReportNameColumns(
     reportName: string,
-    params: CommonParameters = {},
+    params: CommonParameters<ReportColumnDefinition> = {},
   ): Promise<Array<ReportColumnDefinition>> {
     return this.request({
       path: `/system/reports/${reportName}/columns`,
@@ -5235,7 +5437,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemReportsByReportNameCount(
     reportName: string,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/reports/${reportName}/count`,
@@ -5244,7 +5446,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSecurityroles(params: CommonParameters = {}): Promise<Array<SecurityRole>> {
+  getSystemSecurityroles(
+    params: CommonParameters<SecurityRole> = {},
+  ): Promise<Array<SecurityRole>> {
     return this.request({
       path: `/system/securityroles`,
       method: 'get',
@@ -5260,7 +5464,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSecurityrolesById(id: number, params: CommonParameters = {}): Promise<SecurityRole> {
+  getSystemSecurityrolesById(
+    id: number,
+    params: CommonParameters<SecurityRole> = {},
+  ): Promise<SecurityRole> {
     return this.request({
       path: `/system/securityroles/${id}`,
       method: 'get',
@@ -5277,7 +5484,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemSecurityrolesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<SecurityRoleInfo> = {},
   ): Promise<SecurityRoleInfo> {
     return this.request({
       path: `/system/securityroles/${id}/info`,
@@ -5288,7 +5495,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemSecurityRolesByParentIdSettings(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<SecurityRoleSetting> = {},
   ): Promise<Array<SecurityRoleSetting>> {
     return this.request({
       path: `/system/securityRoles/${parentId}/settings`,
@@ -5300,7 +5507,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemSecurityRolesByParentIdSettingsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<SecurityRoleSetting> = {},
   ): Promise<SecurityRoleSetting> {
     return this.request({
       path: `/system/securityRoles/${parentId}/settings/${id}`,
@@ -5311,7 +5518,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemSecurityRolesByParentIdSettingsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/securityRoles/${parentId}/settings/count`,
@@ -5320,7 +5527,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSecurityrolesCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemSecurityrolesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/securityroles/count`,
       method: 'get',
@@ -5328,7 +5535,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSecurityrolesInfo(params: CommonParameters = {}): Promise<Array<SecurityRoleInfo>> {
+  getSystemSecurityrolesInfo(
+    params: CommonParameters<SecurityRoleInfo> = {},
+  ): Promise<Array<SecurityRoleInfo>> {
     return this.request({
       path: `/system/securityroles/info`,
       method: 'get',
@@ -5336,7 +5545,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSecurityrolesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemSecurityrolesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/securityroles/info/count`,
       method: 'get',
@@ -5344,7 +5553,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSettings(params: CommonParameters = {}): Promise<Array<SystemSetting>> {
+  getSystemSettings(params: CommonParameters<SystemSetting> = {}): Promise<Array<SystemSetting>> {
     return this.request({
       path: `/system/settings`,
       method: 'get',
@@ -5352,7 +5561,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSettingsById(id: number, params: CommonParameters = {}): Promise<SystemSetting> {
+  getSystemSettingsById(
+    id: number,
+    params: CommonParameters<SystemSetting> = {},
+  ): Promise<SystemSetting> {
     return this.request({
       path: `/system/settings/${id}`,
       method: 'get',
@@ -5379,7 +5591,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSettingsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemSettingsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/settings/count`,
       method: 'get',
@@ -5387,7 +5599,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSetupScreens(params: CommonParameters = {}): Promise<Array<SetupScreen>> {
+  getSystemSetupScreens(params: CommonParameters<SetupScreen> = {}): Promise<Array<SetupScreen>> {
     return this.request({
       path: `/system/setupScreens`,
       method: 'get',
@@ -5395,7 +5607,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSetupScreensById(id: number, params: CommonParameters = {}): Promise<SetupScreen> {
+  getSystemSetupScreensById(
+    id: number,
+    params: CommonParameters<SetupScreen> = {},
+  ): Promise<SetupScreen> {
     return this.request({
       path: `/system/setupScreens/${id}`,
       method: 'get',
@@ -5403,7 +5618,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSetupScreensCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemSetupScreensCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/setupScreens/count`,
       method: 'get',
@@ -5411,7 +5626,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSkillCategories(params: CommonParameters = {}): Promise<Array<SkillCategory>> {
+  getSystemSkillCategories(
+    params: CommonParameters<SkillCategory> = {},
+  ): Promise<Array<SkillCategory>> {
     return this.request({
       path: `/system/skillCategories`,
       method: 'get',
@@ -5427,7 +5644,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSkillCategoriesById(id: number, params: CommonParameters = {}): Promise<SkillCategory> {
+  getSystemSkillCategoriesById(
+    id: number,
+    params: CommonParameters<SkillCategory> = {},
+  ): Promise<SkillCategory> {
     return this.request({
       path: `/system/skillCategories/${id}`,
       method: 'get',
@@ -5461,7 +5681,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSkillCategoriesCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemSkillCategoriesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/skillCategories/count`,
       method: 'get',
@@ -5469,7 +5689,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSkills(params: CommonParameters = {}): Promise<Array<Skill>> {
+  getSystemSkills(params: CommonParameters<Skill> = {}): Promise<Array<Skill>> {
     return this.request({
       path: `/system/skills`,
       method: 'get',
@@ -5485,7 +5705,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSkillsById(id: number, params: CommonParameters = {}): Promise<Skill> {
+  getSystemSkillsById(id: number, params: CommonParameters<Skill> = {}): Promise<Skill> {
     return this.request({
       path: `/system/skills/${id}`,
       method: 'get',
@@ -5516,7 +5736,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSkillsByIdInfo(id: number, params: CommonParameters = {}): Promise<SkillInfo> {
+  getSystemSkillsByIdInfo(
+    id: number,
+    params: CommonParameters<SkillInfo> = {},
+  ): Promise<SkillInfo> {
     return this.request({
       path: `/system/skills/${id}/info`,
       method: 'get',
@@ -5524,7 +5747,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSkillsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemSkillsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/skills/count`,
       method: 'get',
@@ -5532,7 +5755,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSkillsInfo(params: CommonParameters = {}): Promise<Array<SkillInfo>> {
+  getSystemSkillsInfo(params: CommonParameters<SkillInfo> = {}): Promise<Array<SkillInfo>> {
     return this.request({
       path: `/system/skills/info`,
       method: 'get',
@@ -5540,7 +5763,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSkillsInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemSkillsInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/skills/info/count`,
       method: 'get',
@@ -5548,7 +5771,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSsoConfigurations(params: CommonParameters = {}): Promise<Array<SsoConfiguration>> {
+  getSystemSsoConfigurations(
+    params: CommonParameters<SsoConfiguration> = {},
+  ): Promise<Array<SsoConfiguration>> {
     return this.request({
       path: `/system/ssoConfigurations`,
       method: 'get',
@@ -5566,7 +5791,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemSsoConfigurationsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<SsoConfiguration> = {},
   ): Promise<SsoConfiguration> {
     return this.request({
       path: `/system/ssoConfigurations/${id}`,
@@ -5626,7 +5851,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSsoConfigurationsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemSsoConfigurationsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/ssoConfigurations/count`,
       method: 'get',
@@ -5634,7 +5859,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSsoUsers(params: CommonParameters = {}): Promise<Array<SsoUser>> {
+  getSystemSsoUsers(params: CommonParameters<SsoUser> = {}): Promise<Array<SsoUser>> {
     return this.request({
       path: `/system/ssoUsers`,
       method: 'get',
@@ -5644,7 +5869,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemSsoUsersByExternalId(
     externalId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<SsoUser> = {},
   ): Promise<SsoUser> {
     return this.request({
       path: `/system/ssoUsers/${externalId}`,
@@ -5653,7 +5878,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSsoUsersCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemSsoUsersCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/ssoUsers/count`,
       method: 'get',
@@ -5661,7 +5886,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemStandardNotes(params: CommonParameters = {}): Promise<Array<StandardNote>> {
+  getSystemStandardNotes(
+    params: CommonParameters<StandardNote> = {},
+  ): Promise<Array<StandardNote>> {
     return this.request({
       path: `/system/standardNotes`,
       method: 'get',
@@ -5677,7 +5904,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemStandardNotesById(id: number, params: CommonParameters = {}): Promise<StandardNote> {
+  getSystemStandardNotesById(
+    id: number,
+    params: CommonParameters<StandardNote> = {},
+  ): Promise<StandardNote> {
     return this.request({
       path: `/system/standardNotes/${id}`,
       method: 'get',
@@ -5711,7 +5941,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemStandardNotesCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemStandardNotesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/standardNotes/count`,
       method: 'get',
@@ -5719,7 +5949,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSurveys(params: CommonParameters = {}): Promise<Array<Survey>> {
+  getSystemSurveys(params: CommonParameters<Survey> = {}): Promise<Array<Survey>> {
     return this.request({
       path: `/system/surveys`,
       method: 'get',
@@ -5738,7 +5968,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemSurveysByGrandparentIdQuestionsByParentIdValues(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<SurveyQuestionValue> = {},
   ): Promise<Array<SurveyQuestionValue>> {
     return this.request({
       path: `/system/surveys/${grandparentId}/questions/${parentId}/values`,
@@ -5763,7 +5993,7 @@ export class SystemAPI extends ManageBaseAPI {
     id: number,
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<SurveyQuestionValue> = {},
   ): Promise<SurveyQuestionValue> {
     return this.request({
       path: `/system/surveys/${grandparentId}/questions/${parentId}/values/${id}`,
@@ -5809,7 +6039,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSurveysById(id: number, params: CommonParameters = {}): Promise<Survey> {
+  getSystemSurveysById(id: number, params: CommonParameters<Survey> = {}): Promise<Survey> {
     return this.request({
       path: `/system/surveys/${id}`,
       method: 'get',
@@ -5847,7 +6077,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSurveysByIdInfo(id: number, params: CommonParameters = {}): Promise<SurveyInfo> {
+  getSystemSurveysByIdInfo(
+    id: number,
+    params: CommonParameters<SurveyInfo> = {},
+  ): Promise<SurveyInfo> {
     return this.request({
       path: `/system/surveys/${id}/info`,
       method: 'get',
@@ -5857,7 +6090,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemSurveysByParentIdQuestions(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<SurveyQuestion> = {},
   ): Promise<Array<SurveyQuestion>> {
     return this.request({
       path: `/system/surveys/${parentId}/questions`,
@@ -5880,7 +6113,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemSurveysByParentIdQuestionsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<SurveyQuestion> = {},
   ): Promise<SurveyQuestion> {
     return this.request({
       path: `/system/surveys/${parentId}/questions/${id}`,
@@ -5925,7 +6158,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemSurveysByParentIdQuestionsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/surveys/${parentId}/questions/count`,
@@ -5934,7 +6167,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSurveysCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemSurveysCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/surveys/count`,
       method: 'get',
@@ -5942,7 +6175,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSurveysInfo(params: CommonParameters = {}): Promise<Array<SurveyInfo>> {
+  getSystemSurveysInfo(params: CommonParameters<SurveyInfo> = {}): Promise<Array<SurveyInfo>> {
     return this.request({
       path: `/system/surveys/info`,
       method: 'get',
@@ -5950,7 +6183,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemSurveysInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemSurveysInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/surveys/info/count`,
       method: 'get',
@@ -5958,7 +6191,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemTimeZoneSetups(params: CommonParameters = {}): Promise<Array<TimeZoneSetup>> {
+  getSystemTimeZoneSetups(
+    params: CommonParameters<TimeZoneSetup> = {},
+  ): Promise<Array<TimeZoneSetup>> {
     return this.request({
       path: `/system/timeZoneSetups`,
       method: 'get',
@@ -5974,7 +6209,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemTimeZoneSetupsById(id: number, params: CommonParameters = {}): Promise<TimeZoneSetup> {
+  getSystemTimeZoneSetupsById(
+    id: number,
+    params: CommonParameters<TimeZoneSetup> = {},
+  ): Promise<TimeZoneSetup> {
     return this.request({
       path: `/system/timeZoneSetups/${id}`,
       method: 'get',
@@ -6010,7 +6248,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemTimeZoneSetupsByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TimeZoneSetupInfo> = {},
   ): Promise<TimeZoneSetupInfo> {
     return this.request({
       path: `/system/timeZoneSetups/${id}/info`,
@@ -6019,7 +6257,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemTimeZoneSetupsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemTimeZoneSetupsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/timeZoneSetups/count`,
       method: 'get',
@@ -6027,7 +6265,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemTimeZoneSetupsInfo(params: CommonParameters = {}): Promise<Array<TimeZoneSetupInfo>> {
+  getSystemTimeZoneSetupsInfo(
+    params: CommonParameters<TimeZoneSetupInfo> = {},
+  ): Promise<Array<TimeZoneSetupInfo>> {
     return this.request({
       path: `/system/timeZoneSetups/info`,
       method: 'get',
@@ -6035,7 +6275,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemTimeZoneSetupsInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemTimeZoneSetupsInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/timeZoneSetups/info/count`,
       method: 'get',
@@ -6043,7 +6283,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemTodayPageCategories(params: CommonParameters = {}): Promise<Array<TodayPageCategory>> {
+  getSystemTodayPageCategories(
+    params: CommonParameters<TodayPageCategory> = {},
+  ): Promise<Array<TodayPageCategory>> {
     return this.request({
       path: `/system/todayPageCategories`,
       method: 'get',
@@ -6061,7 +6303,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemTodayPageCategoriesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TodayPageCategory> = {},
   ): Promise<TodayPageCategory> {
     return this.request({
       path: `/system/todayPageCategories/${id}`,
@@ -6099,7 +6341,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemTodayPageCategoriesCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemTodayPageCategoriesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/todayPageCategories/count`,
       method: 'get',
@@ -6107,7 +6349,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemTodayPagelinks(params: CommonParameters = {}): Promise<Array<TodayPageLink>> {
+  getSystemTodayPagelinks(
+    params: CommonParameters<TodayPageLink> = {},
+  ): Promise<Array<TodayPageLink>> {
     return this.request({
       path: `/system/todayPagelinks`,
       method: 'get',
@@ -6123,7 +6367,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemTodayPagelinksById(id: number, params: CommonParameters = {}): Promise<TodayPageLink> {
+  getSystemTodayPagelinksById(
+    id: number,
+    params: CommonParameters<TodayPageLink> = {},
+  ): Promise<TodayPageLink> {
     return this.request({
       path: `/system/todayPagelinks/${id}`,
       method: 'get',
@@ -6160,7 +6407,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemTodayPagelinksCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemTodayPagelinksCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/todayPagelinks/count`,
       method: 'get',
@@ -6168,7 +6415,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemUserDefinedFields(params: CommonParameters = {}): Promise<Array<UserDefinedField>> {
+  getSystemUserDefinedFields(
+    params: CommonParameters<UserDefinedField> = {},
+  ): Promise<Array<UserDefinedField>> {
     return this.request({
       path: `/system/userDefinedFields`,
       method: 'get',
@@ -6186,7 +6435,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemUserDefinedFieldsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<UserDefinedField> = {},
   ): Promise<UserDefinedField> {
     return this.request({
       path: `/system/userDefinedFields/${id}`,
@@ -6226,7 +6475,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemUserDefinedFieldsByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<UserDefinedFieldInfo> = {},
   ): Promise<UserDefinedFieldInfo> {
     return this.request({
       path: `/system/userDefinedFields/${id}/info`,
@@ -6235,7 +6484,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemUserDefinedFieldsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemUserDefinedFieldsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/userDefinedFields/count`,
       method: 'get',
@@ -6244,7 +6493,7 @@ export class SystemAPI extends ManageBaseAPI {
   }
 
   getSystemUserDefinedFieldsInfo(
-    params: CommonParameters = {},
+    params: CommonParameters<UserDefinedFieldInfo> = {},
   ): Promise<Array<UserDefinedFieldInfo>> {
     return this.request({
       path: `/system/userDefinedFields/info`,
@@ -6253,7 +6502,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemUserDefinedFieldsInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemUserDefinedFieldsInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/userDefinedFields/info/count`,
       method: 'get',
@@ -6263,7 +6512,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemWorkflowActionsByParentIdAutomateParameters(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WorkflowActionAutomateParameter> = {},
   ): Promise<Array<WorkflowActionAutomateParameter>> {
     return this.request({
       path: `/system/workflowActions/${parentId}/automateParameters`,
@@ -6286,7 +6535,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemWorkflowActionsByParentIdAutomateParametersById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WorkflowActionAutomateParameter> = {},
   ): Promise<WorkflowActionAutomateParameter> {
     return this.request({
       path: `/system/workflowActions/${parentId}/automateParameters/${id}`,
@@ -6331,7 +6580,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemWorkflowActionsByParentIdAutomateParametersCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/workflowActions/${parentId}/automateParameters/count`,
@@ -6341,7 +6590,7 @@ export class SystemAPI extends ManageBaseAPI {
   }
 
   getSystemWorkflowActionsAutomateParameters(
-    params: CommonParameters = {},
+    params: CommonParameters<WorkflowActionAutomateParameter> = {},
   ): Promise<Array<WorkflowActionAutomateParameter>> {
     return this.request({
       path: `/system/workflowActions/automateParameters`,
@@ -6352,7 +6601,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemWorkflowActionsAutomateParametersById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WorkflowActionAutomateParameter> = {},
   ): Promise<WorkflowActionAutomateParameter> {
     return this.request({
       path: `/system/workflowActions/automateParameters/${id}`,
@@ -6361,7 +6610,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemWorkflows(params: CommonParameters = {}): Promise<Array<Workflow>> {
+  getSystemWorkflows(params: CommonParameters<Workflow> = {}): Promise<Array<Workflow>> {
     return this.request({
       path: `/system/workflows`,
       method: 'get',
@@ -6380,7 +6629,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemWorkflowsByGrandparentIdEventsByParentIdActions(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WorkflowAction> = {},
   ): Promise<Array<WorkflowAction>> {
     return this.request({
       path: `/system/workflows/${grandparentId}/events/${parentId}/actions`,
@@ -6405,7 +6654,7 @@ export class SystemAPI extends ManageBaseAPI {
     id: number,
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WorkflowAction> = {},
   ): Promise<WorkflowAction> {
     return this.request({
       path: `/system/workflows/${grandparentId}/events/${parentId}/actions/${id}`,
@@ -6454,7 +6703,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemWorkflowsByGrandparentIdEventsByParentIdActionsCount(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/workflows/${grandparentId}/events/${parentId}/actions/count`,
@@ -6466,7 +6715,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemWorkflowsByGrandparentIdTriggersByParentIdOptions(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WorkflowTriggerOption> = {},
   ): Promise<Array<WorkflowTriggerOption>> {
     return this.request({
       path: `/system/workflows/${grandparentId}/triggers/${parentId}/options`,
@@ -6478,7 +6727,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemWorkflowsByGrandparentIdTriggersByParentIdOptionsCount(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/workflows/${grandparentId}/triggers/${parentId}/options/count`,
@@ -6487,7 +6736,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemWorkflowsById(id: number, params: CommonParameters = {}): Promise<Workflow> {
+  getSystemWorkflowsById(id: number, params: CommonParameters<Workflow> = {}): Promise<Workflow> {
     return this.request({
       path: `/system/workflows/${id}`,
       method: 'get',
@@ -6527,7 +6776,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemWorkflowsByParentIdAttachments(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WorkflowAttachment> = {},
   ): Promise<Array<WorkflowAttachment>> {
     return this.request({
       path: `/system/workflows/${parentId}/attachments`,
@@ -6539,7 +6788,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemWorkflowsByParentIdAttachmentsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WorkflowAttachment> = {},
   ): Promise<WorkflowAttachment> {
     return this.request({
       path: `/system/workflows/${parentId}/attachments/${id}`,
@@ -6550,7 +6799,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemWorkflowsByParentIdAttachmentsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/workflows/${parentId}/attachments/count`,
@@ -6561,7 +6810,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemWorkflowsByParentIdEvents(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WorkflowEvent> = {},
   ): Promise<Array<WorkflowEvent>> {
     return this.request({
       path: `/system/workflows/${parentId}/events`,
@@ -6584,7 +6833,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemWorkflowsByParentIdEventsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WorkflowEvent> = {},
   ): Promise<WorkflowEvent> {
     return this.request({
       path: `/system/workflows/${parentId}/events/${id}`,
@@ -6640,7 +6889,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemWorkflowsByParentIdEventsByIdTest(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<object> = {},
   ): Promise<Array<object>> {
     return this.request({
       path: `/system/workflows/${parentId}/events/${id}/test`,
@@ -6651,7 +6900,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemWorkflowsByParentIdEventsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/workflows/${parentId}/events/count`,
@@ -6662,7 +6911,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemWorkflowsByParentIdNotifyTypes(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WorkflowNotifyType> = {},
   ): Promise<Array<WorkflowNotifyType>> {
     return this.request({
       path: `/system/workflows/${parentId}/notifyTypes`,
@@ -6674,7 +6923,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemWorkflowsByParentIdNotifyTypesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WorkflowNotifyType> = {},
   ): Promise<WorkflowNotifyType> {
     return this.request({
       path: `/system/workflows/${parentId}/notifyTypes/${id}`,
@@ -6686,7 +6935,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemWorkflowsByParentIdNotifyTypesByIdInfo(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WorkflowNotifyTypeInfo> = {},
   ): Promise<WorkflowNotifyTypeInfo> {
     return this.request({
       path: `/system/workflows/${parentId}/notifyTypes/${id}/info`,
@@ -6697,7 +6946,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemWorkflowsByParentIdNotifyTypesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/workflows/${parentId}/notifyTypes/count`,
@@ -6708,7 +6957,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemWorkflowsByParentIdNotifyTypesInfo(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WorkflowNotifyTypeInfo> = {},
   ): Promise<Array<WorkflowNotifyTypeInfo>> {
     return this.request({
       path: `/system/workflows/${parentId}/notifyTypes/info`,
@@ -6719,7 +6968,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemWorkflowsByParentIdNotifyTypesInfoCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/workflows/${parentId}/notifyTypes/info/count`,
@@ -6730,7 +6979,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemWorkflowsByParentIdTriggers(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WorkflowTrigger> = {},
   ): Promise<Array<WorkflowTrigger>> {
     return this.request({
       path: `/system/workflows/${parentId}/triggers`,
@@ -6741,7 +6990,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemWorkflowsByParentIdTriggersCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/system/workflows/${parentId}/triggers/count`,
@@ -6750,7 +6999,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemWorkflowsAttachments(params: CommonParameters = {}): Promise<Array<WorkflowAttachment>> {
+  getSystemWorkflowsAttachments(
+    params: CommonParameters<WorkflowAttachment> = {},
+  ): Promise<Array<WorkflowAttachment>> {
     return this.request({
       path: `/system/workflows/attachments`,
       method: 'get',
@@ -6760,7 +7011,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemWorkflowsAttachmentsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WorkflowAttachment> = {},
   ): Promise<Array<WorkflowAttachment>> {
     return this.request({
       path: `/system/workflows/attachments/${id}`,
@@ -6769,7 +7020,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemWorkflowsCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemWorkflowsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/workflows/count`,
       method: 'get',
@@ -6777,7 +7028,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemWorkflowsEvents(params: CommonParameters = {}): Promise<Array<WorkflowEvent>> {
+  getSystemWorkflowsEvents(
+    params: CommonParameters<WorkflowEvent> = {},
+  ): Promise<Array<WorkflowEvent>> {
     return this.request({
       path: `/system/workflows/events`,
       method: 'get',
@@ -6785,7 +7038,10 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemWorkflowsEventsById(id: number, params: CommonParameters = {}): Promise<WorkflowEvent> {
+  getSystemWorkflowsEventsById(
+    id: number,
+    params: CommonParameters<WorkflowEvent> = {},
+  ): Promise<WorkflowEvent> {
     return this.request({
       path: `/system/workflows/events/${id}`,
       method: 'get',
@@ -6793,7 +7049,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemWorkflowsEventsActions(params: CommonParameters = {}): Promise<Array<WorkflowAction>> {
+  getSystemWorkflowsEventsActions(
+    params: CommonParameters<WorkflowAction> = {},
+  ): Promise<Array<WorkflowAction>> {
     return this.request({
       path: `/system/workflows/events/actions`,
       method: 'get',
@@ -6803,7 +7061,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemWorkflowsEventsActionsById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WorkflowAction> = {},
   ): Promise<WorkflowAction> {
     return this.request({
       path: `/system/workflows/events/actions/${id}`,
@@ -6812,7 +7070,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemWorkflowsNotifyTypes(params: CommonParameters = {}): Promise<Array<WorkflowNotifyType>> {
+  getSystemWorkflowsNotifyTypes(
+    params: CommonParameters<WorkflowNotifyType> = {},
+  ): Promise<Array<WorkflowNotifyType>> {
     return this.request({
       path: `/system/workflows/notifyTypes`,
       method: 'get',
@@ -6822,7 +7082,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemWorkflowsNotifyTypesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WorkflowNotifyType> = {},
   ): Promise<Array<WorkflowNotifyType>> {
     return this.request({
       path: `/system/workflows/notifyTypes/${id}`,
@@ -6831,7 +7091,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemWorkflowsTableTypes(params: CommonParameters = {}): Promise<Array<WorkflowTableType>> {
+  getSystemWorkflowsTableTypes(
+    params: CommonParameters<WorkflowTableType> = {},
+  ): Promise<Array<WorkflowTableType>> {
     return this.request({
       path: `/system/workflows/tableTypes`,
       method: 'get',
@@ -6841,7 +7103,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemWorkflowsTableTypesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WorkflowTableType> = {},
   ): Promise<WorkflowTableType> {
     return this.request({
       path: `/system/workflows/tableTypes/${id}`,
@@ -6852,7 +7114,7 @@ export class SystemAPI extends ManageBaseAPI {
 
   getSystemWorkflowsTableTypesByIdInfo(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WorkflowTableTypeInfo> = {},
   ): Promise<WorkflowTableTypeInfo> {
     return this.request({
       path: `/system/workflows/tableTypes/${id}/info`,
@@ -6861,7 +7123,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemWorkflowsTableTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemWorkflowsTableTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/workflows/tableTypes/count`,
       method: 'get',
@@ -6870,7 +7132,7 @@ export class SystemAPI extends ManageBaseAPI {
   }
 
   getSystemWorkflowsTableTypesInfo(
-    params: CommonParameters = {},
+    params: CommonParameters<WorkflowTableTypeInfo> = {},
   ): Promise<Array<WorkflowTableTypeInfo>> {
     return this.request({
       path: `/system/workflows/tableTypes/info`,
@@ -6879,7 +7141,7 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemWorkflowsTableTypesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getSystemWorkflowsTableTypesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/system/workflows/tableTypes/info/count`,
       method: 'get',
@@ -6887,7 +7149,9 @@ export class SystemAPI extends ManageBaseAPI {
     })
   }
 
-  getSystemWorkflowsTriggers(params: CommonParameters = {}): Promise<Array<WorkflowTrigger>> {
+  getSystemWorkflowsTriggers(
+    params: CommonParameters<WorkflowTrigger> = {},
+  ): Promise<Array<WorkflowTrigger>> {
     return this.request({
       path: `/system/workflows/triggers`,
       method: 'get',
@@ -6896,7 +7160,7 @@ export class SystemAPI extends ManageBaseAPI {
   }
 
   getSystemWorkflowsTriggersOptions(
-    params: CommonParameters = {},
+    params: CommonParameters<WorkflowTriggerOption> = {},
   ): Promise<Array<WorkflowTriggerOption>> {
     return this.request({
       path: `/system/workflows/triggers/options`,
@@ -6950,7 +7214,7 @@ export class SystemAPI extends ManageBaseAPI {
   getSystemWorkflowsUserdefinedfieldsEventsByGrandparentIdActionsByParentId(
     parentId: number,
     grandparentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WorkflowActionUserDefinedField> = {},
   ): Promise<Array<WorkflowActionUserDefinedField>> {
     return this.request({
       path: `/system/workflows/userdefinedfields/events/${grandparentId}/actions/${parentId}`,
@@ -6960,7 +7224,7 @@ export class SystemAPI extends ManageBaseAPI {
   }
 
   getSystemWorkflowsUserdefinedfieldsEventsActions(
-    params: CommonParameters = {},
+    params: CommonParameters<WorkflowActionUserDefinedField> = {},
   ): Promise<Array<WorkflowActionUserDefinedField>> {
     return this.request({
       path: `/system/workflows/userdefinedfields/events/actions`,

--- a/src/Manage/TimeAPI.ts
+++ b/src/Manage/TimeAPI.ts
@@ -66,7 +66,7 @@ export type WorkTypeInfo = schemas['WorkTypeInfo']
  * @public
  */
 export class TimeAPI extends ManageBaseAPI {
-  getTimeAccruals(params: CommonParameters = {}): Promise<Array<TimeAccrual>> {
+  getTimeAccruals(params: CommonParameters<TimeAccrual> = {}): Promise<Array<TimeAccrual>> {
     return this.request({
       path: `/time/accruals`,
       method: 'get',
@@ -82,7 +82,10 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeAccrualsById(id: number, params: CommonParameters = {}): Promise<TimeAccrual> {
+  getTimeAccrualsById(
+    id: number,
+    params: CommonParameters<TimeAccrual> = {},
+  ): Promise<TimeAccrual> {
     return this.request({
       path: `/time/accruals/${id}`,
       method: 'get',
@@ -115,7 +118,7 @@ export class TimeAPI extends ManageBaseAPI {
 
   getTimeAccrualsByParentIdDetails(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TimeAccrualDetail> = {},
   ): Promise<Array<TimeAccrualDetail>> {
     return this.request({
       path: `/time/accruals/${parentId}/details`,
@@ -138,7 +141,7 @@ export class TimeAPI extends ManageBaseAPI {
   getTimeAccrualsByParentIdDetailsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TimeAccrualDetail> = {},
   ): Promise<TimeAccrualDetail> {
     return this.request({
       path: `/time/accruals/${parentId}/details/${id}`,
@@ -183,7 +186,7 @@ export class TimeAPI extends ManageBaseAPI {
 
   getTimeAccrualsByParentIdDetailsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/time/accruals/${parentId}/details/count`,
@@ -192,7 +195,7 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeAccrualsCount(params: CommonParameters = {}): Promise<Count> {
+  getTimeAccrualsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/time/accruals/count`,
       method: 'get',
@@ -200,7 +203,9 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeActivitystopwatches(params: CommonParameters = {}): Promise<Array<ActivityStopwatch>> {
+  getTimeActivitystopwatches(
+    params: CommonParameters<ActivityStopwatch> = {},
+  ): Promise<Array<ActivityStopwatch>> {
     return this.request({
       path: `/time/activitystopwatches`,
       method: 'get',
@@ -218,7 +223,7 @@ export class TimeAPI extends ManageBaseAPI {
 
   getTimeActivitystopwatchesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ActivityStopwatch> = {},
   ): Promise<ActivityStopwatch> {
     return this.request({
       path: `/time/activitystopwatches/${id}`,
@@ -256,7 +261,7 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeActivitystopwatchesCount(params: CommonParameters = {}): Promise<Count> {
+  getTimeActivitystopwatchesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/time/activitystopwatches/count`,
       method: 'get',
@@ -264,7 +269,9 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeChangelogs(params: CommonParameters = {}): Promise<Array<TimeEntryChangeLog>> {
+  getTimeChangelogs(
+    params: CommonParameters<TimeEntryChangeLog> = {},
+  ): Promise<Array<TimeEntryChangeLog>> {
     return this.request({
       path: `/time/changelogs`,
       method: 'get',
@@ -279,7 +286,7 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeChargeCodes(params: CommonParameters = {}): Promise<Array<ChargeCode>> {
+  getTimeChargeCodes(params: CommonParameters<ChargeCode> = {}): Promise<Array<ChargeCode>> {
     return this.request({
       path: `/time/chargeCodes`,
       method: 'get',
@@ -295,7 +302,10 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeChargeCodesById(id: number, params: CommonParameters = {}): Promise<ChargeCode> {
+  getTimeChargeCodesById(
+    id: number,
+    params: CommonParameters<ChargeCode> = {},
+  ): Promise<ChargeCode> {
     return this.request({
       path: `/time/chargeCodes/${id}`,
       method: 'get',
@@ -329,7 +339,10 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeChargeCodesByIdInfo(id: number, params: CommonParameters = {}): Promise<ChargeCodeInfo> {
+  getTimeChargeCodesByIdInfo(
+    id: number,
+    params: CommonParameters<ChargeCodeInfo> = {},
+  ): Promise<ChargeCodeInfo> {
     return this.request({
       path: `/time/chargeCodes/${id}/info`,
       method: 'get',
@@ -337,7 +350,10 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeChargeCodesByIdUsages(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getTimeChargeCodesByIdUsages(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/time/chargeCodes/${id}/usages`,
       method: 'get',
@@ -347,7 +363,7 @@ export class TimeAPI extends ManageBaseAPI {
 
   getTimeChargeCodesByIdUsagesList(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Usage> = {},
   ): Promise<Array<Usage>> {
     return this.request({
       path: `/time/chargeCodes/${id}/usages/list`,
@@ -358,7 +374,7 @@ export class TimeAPI extends ManageBaseAPI {
 
   getTimeChargeCodesByParentIdExpenseTypes(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ChargeCodeExpenseType> = {},
   ): Promise<Array<ChargeCodeExpenseType>> {
     return this.request({
       path: `/time/chargeCodes/${parentId}/expenseTypes`,
@@ -381,7 +397,7 @@ export class TimeAPI extends ManageBaseAPI {
   getTimeChargeCodesByParentIdExpenseTypesById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ChargeCodeExpenseType> = {},
   ): Promise<ChargeCodeExpenseType> {
     return this.request({
       path: `/time/chargeCodes/${parentId}/expenseTypes/${id}`,
@@ -426,7 +442,7 @@ export class TimeAPI extends ManageBaseAPI {
 
   getTimeChargeCodesByParentIdExpenseTypesCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/time/chargeCodes/${parentId}/expenseTypes/count`,
@@ -435,7 +451,7 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeChargeCodesCount(params: CommonParameters = {}): Promise<Count> {
+  getTimeChargeCodesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/time/chargeCodes/count`,
       method: 'get',
@@ -443,7 +459,9 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeChargeCodesInfo(params: CommonParameters = {}): Promise<Array<ChargeCodeInfo>> {
+  getTimeChargeCodesInfo(
+    params: CommonParameters<ChargeCodeInfo> = {},
+  ): Promise<Array<ChargeCodeInfo>> {
     return this.request({
       path: `/time/chargeCodes/info`,
       method: 'get',
@@ -451,7 +469,7 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeChargeCodesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getTimeChargeCodesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/time/chargeCodes/info/count`,
       method: 'get',
@@ -459,7 +477,7 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeEntries(params: CommonParameters = {}): Promise<Array<TimeEntry>> {
+  getTimeEntries(params: CommonParameters<TimeEntry> = {}): Promise<Array<TimeEntry>> {
     return this.request({
       path: `/time/entries`,
       method: 'get',
@@ -475,7 +493,7 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeEntriesById(id: number, params: CommonParameters = {}): Promise<TimeEntry> {
+  getTimeEntriesById(id: number, params: CommonParameters<TimeEntry> = {}): Promise<TimeEntry> {
     return this.request({
       path: `/time/entries/${id}`,
       method: 'get',
@@ -537,7 +555,7 @@ export class TimeAPI extends ManageBaseAPI {
 
   getTimeEntriesByParentIdAudits(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TimeEntryAudit> = {},
   ): Promise<Array<TimeEntryAudit>> {
     return this.request({
       path: `/time/entries/${parentId}/audits`,
@@ -549,7 +567,7 @@ export class TimeAPI extends ManageBaseAPI {
   getTimeEntriesByParentIdAuditsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TimeEntryAudit> = {},
   ): Promise<TimeEntryAudit> {
     return this.request({
       path: `/time/entries/${parentId}/audits/${id}`,
@@ -560,7 +578,7 @@ export class TimeAPI extends ManageBaseAPI {
 
   getTimeEntriesByParentIdAuditsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/time/entries/${parentId}/audits/count`,
@@ -569,7 +587,7 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeEntriesCount(params: CommonParameters = {}): Promise<Count> {
+  getTimeEntriesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/time/entries/count`,
       method: 'get',
@@ -586,7 +604,7 @@ export class TimeAPI extends ManageBaseAPI {
   }
 
   getTimeInfoChargeCodeExpenseTypes(
-    params: CommonParameters = {},
+    params: CommonParameters<ChargeCodeExpenseType> = {},
   ): Promise<Array<ChargeCodeExpenseType>> {
     return this.request({
       path: `/time/info/chargeCodeExpenseTypes`,
@@ -595,7 +613,7 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeInfoChargeCodeExpenseTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getTimeInfoChargeCodeExpenseTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/time/info/chargeCodeExpenseTypes/count`,
       method: 'get',
@@ -603,7 +621,9 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeSchedulestopwatches(params: CommonParameters = {}): Promise<Array<ScheduleStopwatch>> {
+  getTimeSchedulestopwatches(
+    params: CommonParameters<ScheduleStopwatch> = {},
+  ): Promise<Array<ScheduleStopwatch>> {
     return this.request({
       path: `/time/schedulestopwatches`,
       method: 'get',
@@ -621,7 +641,7 @@ export class TimeAPI extends ManageBaseAPI {
 
   getTimeSchedulestopwatchesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<ScheduleStopwatch> = {},
   ): Promise<ScheduleStopwatch> {
     return this.request({
       path: `/time/schedulestopwatches/${id}`,
@@ -659,7 +679,7 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeSchedulestopwatchesCount(params: CommonParameters = {}): Promise<Count> {
+  getTimeSchedulestopwatchesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/time/schedulestopwatches/count`,
       method: 'get',
@@ -667,7 +687,7 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeSheets(params: CommonParameters = {}): Promise<Array<TimeSheet>> {
+  getTimeSheets(params: CommonParameters<TimeSheet> = {}): Promise<Array<TimeSheet>> {
     return this.request({
       path: `/time/sheets`,
       method: 'get',
@@ -675,7 +695,7 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeSheetsById(id: number, params: CommonParameters = {}): Promise<TimeSheet> {
+  getTimeSheetsById(id: number, params: CommonParameters<TimeSheet> = {}): Promise<TimeSheet> {
     return this.request({
       path: `/time/sheets/${id}`,
       method: 'get',
@@ -721,7 +741,7 @@ export class TimeAPI extends ManageBaseAPI {
 
   getTimeSheetsByParentIdAudits(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TimeSheetAudit> = {},
   ): Promise<Array<TimeSheetAudit>> {
     return this.request({
       path: `/time/sheets/${parentId}/audits`,
@@ -733,7 +753,7 @@ export class TimeAPI extends ManageBaseAPI {
   getTimeSheetsByParentIdAuditsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TimeSheetAudit> = {},
   ): Promise<TimeSheetAudit> {
     return this.request({
       path: `/time/sheets/${parentId}/audits/${id}`,
@@ -744,7 +764,7 @@ export class TimeAPI extends ManageBaseAPI {
 
   getTimeSheetsByParentIdAuditsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/time/sheets/${parentId}/audits/count`,
@@ -753,7 +773,7 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeSheetsCount(params: CommonParameters = {}): Promise<Count> {
+  getTimeSheetsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/time/sheets/count`,
       method: 'get',
@@ -761,7 +781,9 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeTicketstopwatches(params: CommonParameters = {}): Promise<Array<TicketStopwatch>> {
+  getTimeTicketstopwatches(
+    params: CommonParameters<TicketStopwatch> = {},
+  ): Promise<Array<TicketStopwatch>> {
     return this.request({
       path: `/time/ticketstopwatches`,
       method: 'get',
@@ -779,7 +801,7 @@ export class TimeAPI extends ManageBaseAPI {
 
   getTimeTicketstopwatchesById(
     id: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TicketStopwatch> = {},
   ): Promise<TicketStopwatch> {
     return this.request({
       path: `/time/ticketstopwatches/${id}`,
@@ -817,7 +839,7 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeTicketstopwatchesCount(params: CommonParameters = {}): Promise<Count> {
+  getTimeTicketstopwatchesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/time/ticketstopwatches/count`,
       method: 'get',
@@ -825,7 +847,9 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeTimePeriodSetups(params: CommonParameters = {}): Promise<Array<TimePeriodSetup>> {
+  getTimeTimePeriodSetups(
+    params: CommonParameters<TimePeriodSetup> = {},
+  ): Promise<Array<TimePeriodSetup>> {
     return this.request({
       path: `/time/timePeriodSetups`,
       method: 'get',
@@ -841,7 +865,10 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeTimePeriodSetupsById(id: number, params: CommonParameters = {}): Promise<TimePeriodSetup> {
+  getTimeTimePeriodSetupsById(
+    id: number,
+    params: CommonParameters<TimePeriodSetup> = {},
+  ): Promise<TimePeriodSetup> {
     return this.request({
       path: `/time/timePeriodSetups/${id}`,
       method: 'get',
@@ -880,7 +907,7 @@ export class TimeAPI extends ManageBaseAPI {
 
   getTimeTimePeriodSetupsByParentIdPeriods(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TimePeriod> = {},
   ): Promise<Array<TimePeriod>> {
     return this.request({
       path: `/time/timePeriodSetups/${parentId}/periods`,
@@ -892,7 +919,7 @@ export class TimeAPI extends ManageBaseAPI {
   getTimeTimePeriodSetupsByParentIdPeriodsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<TimePeriod> = {},
   ): Promise<TimePeriod> {
     return this.request({
       path: `/time/timePeriodSetups/${parentId}/periods/${id}`,
@@ -903,7 +930,7 @@ export class TimeAPI extends ManageBaseAPI {
 
   getTimeTimePeriodSetupsByParentIdPeriodsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/time/timePeriodSetups/${parentId}/periods/count`,
@@ -912,7 +939,7 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeTimePeriodSetupsCount(params: CommonParameters = {}): Promise<Count> {
+  getTimeTimePeriodSetupsCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/time/timePeriodSetups/count`,
       method: 'get',
@@ -920,7 +947,9 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeTimePeriodSetupsDefault(params: CommonParameters = {}): Promise<TimePeriodSetupDefaults> {
+  getTimeTimePeriodSetupsDefault(
+    params: CommonParameters<TimePeriodSetupDefaults> = {},
+  ): Promise<TimePeriodSetupDefaults> {
     return this.request({
       path: `/time/timePeriodSetups/default`,
       method: 'get',
@@ -928,7 +957,7 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeWorkRoles(params: CommonParameters = {}): Promise<Array<WorkRole>> {
+  getTimeWorkRoles(params: CommonParameters<WorkRole> = {}): Promise<Array<WorkRole>> {
     return this.request({
       path: `/time/workRoles`,
       method: 'get',
@@ -944,7 +973,7 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeWorkRolesById(id: number, params: CommonParameters = {}): Promise<WorkRole> {
+  getTimeWorkRolesById(id: number, params: CommonParameters<WorkRole> = {}): Promise<WorkRole> {
     return this.request({
       path: `/time/workRoles/${id}`,
       method: 'get',
@@ -975,7 +1004,10 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeWorkRolesByIdInfo(id: number, params: CommonParameters = {}): Promise<WorkRoleInfo> {
+  getTimeWorkRolesByIdInfo(
+    id: number,
+    params: CommonParameters<WorkRoleInfo> = {},
+  ): Promise<WorkRoleInfo> {
     return this.request({
       path: `/time/workRoles/${id}/info`,
       method: 'get',
@@ -983,7 +1015,10 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeWorkRolesByIdUsages(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getTimeWorkRolesByIdUsages(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/time/workRoles/${id}/usages`,
       method: 'get',
@@ -991,7 +1026,10 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeWorkRolesByIdUsagesList(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getTimeWorkRolesByIdUsagesList(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/time/workRoles/${id}/usages/list`,
       method: 'get',
@@ -1001,7 +1039,7 @@ export class TimeAPI extends ManageBaseAPI {
 
   getTimeWorkRolesByParentIdLocations(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WorkRoleLocation> = {},
   ): Promise<Array<WorkRoleLocation>> {
     return this.request({
       path: `/time/workRoles/${parentId}/locations`,
@@ -1024,7 +1062,7 @@ export class TimeAPI extends ManageBaseAPI {
   getTimeWorkRolesByParentIdLocationsById(
     id: number,
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<WorkRoleLocation> = {},
   ): Promise<WorkRoleLocation> {
     return this.request({
       path: `/time/workRoles/${parentId}/locations/${id}`,
@@ -1069,7 +1107,7 @@ export class TimeAPI extends ManageBaseAPI {
 
   getTimeWorkRolesByParentIdLocationsCount(
     parentId: number,
-    params: CommonParameters = {},
+    params: CommonParameters<Count> = {},
   ): Promise<Count> {
     return this.request({
       path: `/time/workRoles/${parentId}/locations/count`,
@@ -1078,7 +1116,7 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeWorkRolesCount(params: CommonParameters = {}): Promise<Count> {
+  getTimeWorkRolesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/time/workRoles/count`,
       method: 'get',
@@ -1086,7 +1124,7 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeWorkRolesInfo(params: CommonParameters = {}): Promise<Array<WorkRoleInfo>> {
+  getTimeWorkRolesInfo(params: CommonParameters<WorkRoleInfo> = {}): Promise<Array<WorkRoleInfo>> {
     return this.request({
       path: `/time/workRoles/info`,
       method: 'get',
@@ -1094,7 +1132,7 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeWorkRolesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getTimeWorkRolesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/time/workRoles/info/count`,
       method: 'get',
@@ -1102,7 +1140,7 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeWorkTypes(params: CommonParameters = {}): Promise<Array<WorkType>> {
+  getTimeWorkTypes(params: CommonParameters<WorkType> = {}): Promise<Array<WorkType>> {
     return this.request({
       path: `/time/workTypes`,
       method: 'get',
@@ -1118,7 +1156,7 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeWorkTypesById(id: number, params: CommonParameters = {}): Promise<WorkType> {
+  getTimeWorkTypesById(id: number, params: CommonParameters<WorkType> = {}): Promise<WorkType> {
     return this.request({
       path: `/time/workTypes/${id}`,
       method: 'get',
@@ -1149,7 +1187,10 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeWorkTypesByIdInfo(id: number, params: CommonParameters = {}): Promise<WorkTypeInfo> {
+  getTimeWorkTypesByIdInfo(
+    id: number,
+    params: CommonParameters<WorkTypeInfo> = {},
+  ): Promise<WorkTypeInfo> {
     return this.request({
       path: `/time/workTypes/${id}/info`,
       method: 'get',
@@ -1157,7 +1198,10 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeWorkTypesByIdUsages(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getTimeWorkTypesByIdUsages(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/time/workTypes/${id}/usages`,
       method: 'get',
@@ -1165,7 +1209,10 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeWorkTypesByIdUsagesList(id: number, params: CommonParameters = {}): Promise<Array<Usage>> {
+  getTimeWorkTypesByIdUsagesList(
+    id: number,
+    params: CommonParameters<Usage> = {},
+  ): Promise<Array<Usage>> {
     return this.request({
       path: `/time/workTypes/${id}/usages/list`,
       method: 'get',
@@ -1173,7 +1220,7 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeWorkTypesCount(params: CommonParameters = {}): Promise<Count> {
+  getTimeWorkTypesCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/time/workTypes/count`,
       method: 'get',
@@ -1181,7 +1228,7 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeWorkTypesInfo(params: CommonParameters = {}): Promise<Array<WorkTypeInfo>> {
+  getTimeWorkTypesInfo(params: CommonParameters<WorkTypeInfo> = {}): Promise<Array<WorkTypeInfo>> {
     return this.request({
       path: `/time/workTypes/info`,
       method: 'get',
@@ -1189,7 +1236,7 @@ export class TimeAPI extends ManageBaseAPI {
     })
   }
 
-  getTimeWorkTypesInfoCount(params: CommonParameters = {}): Promise<Count> {
+  getTimeWorkTypesInfoCount(params: CommonParameters<Count> = {}): Promise<Count> {
     return this.request({
       path: `/time/workTypes/info/count`,
       method: 'get',

--- a/src/ManageAPI.ts
+++ b/src/ManageAPI.ts
@@ -101,12 +101,12 @@ type OrderByValue<T> = ReadonlyArray<{
  * @public
  * Manage common parameters
  */
-export type CommonParameters<T> = {
+export type CommonParameters<T = any> = {
   conditions?: string
   childConditions?: string
   customFieldConditions?: string
-  orderBy?: OrderByValue<T>
-  fields?: FieldSelection<T>
+  orderBy?: OrderByValue<T> | string
+  fields?: FieldSelection<T> | string
   page?: number
   pageSize?: number
   pageId?: number

--- a/src/ManageAPI.ts
+++ b/src/ManageAPI.ts
@@ -64,16 +64,49 @@ export interface CWMOptions {
   debug?: boolean
 }
 
+type FieldPathPrimitive = bigint | boolean | null | number | string | symbol | undefined
+
+type FieldPathTerminal = Date | FieldPathPrimitive | RegExp
+
+type FieldPathValue<T> = T extends ReadonlyArray<infer U> ? U : T
+
+type FieldPathDepth = [never, 0, 1, 2, 3, 4, 5]
+
+type FieldPath<T, Depth extends number = 5> = [Depth] extends [never]
+  ? never
+  : T extends FieldPathTerminal
+    ? never
+    : T extends object
+      ? {
+          [K in keyof T & string]: NonNullable<T[K]> extends FieldPathTerminal
+            ? K
+            : NonNullable<FieldPathValue<T[K]>> extends object
+              ? K | `${K}/${FieldPath<NonNullable<FieldPathValue<T[K]>>, FieldPathDepth[Depth]>}`
+              : K
+        }[keyof T & string]
+      : never
+
+type FieldSelection<T> = ReadonlyArray<FieldPath<NonNullable<T>>>
+
+type OrderByField<T> = FieldPath<NonNullable<T>>
+
+type SortOrder = 'asc' | 'desc'
+
+type OrderByValue<T> = ReadonlyArray<{
+  field: OrderByField<T>
+  direction: SortOrder
+}>
+
 /**
  * @public
  * Manage common parameters
  */
-export type CommonParameters = {
+export type CommonParameters<T> = {
   conditions?: string
   childConditions?: string
   customFieldConditions?: string
-  orderBy?: string
-  fields?: string
+  orderBy?: OrderByValue<T>
+  fields?: FieldSelection<T>
   page?: number
   pageSize?: number
   pageId?: number

--- a/test/manage-parameter-types.ts
+++ b/test/manage-parameter-types.ts
@@ -1,0 +1,34 @@
+import { expectTypeOf } from 'expect-type'
+import type { CommonParameters } from '../src/ManageAPI'
+import type { ServiceAPI, Ticket as ManageTicket } from '../src/Manage/ServiceAPI'
+
+declare const serviceApi: ServiceAPI
+
+const serviceTickets = serviceApi.getServiceTickets({
+  fields: ['id', 'summary', 'company/id'],
+  orderBy: [
+    { field: 'company/id', direction: 'asc' },
+    { field: 'summary', direction: 'desc' },
+  ],
+})
+
+expectTypeOf(serviceTickets).toEqualTypeOf<Promise<ManageTicket[]>>()
+
+const ticketParams: CommonParameters<ManageTicket> = {
+  fields: ['id', 'company/id'],
+  orderBy: [{ field: 'summary', direction: 'asc' }],
+}
+
+expectTypeOf(ticketParams).toEqualTypeOf<CommonParameters<ManageTicket>>()
+
+// @ts-expect-error fields should be constrained to Ticket field paths.
+serviceApi.getServiceTickets({ fields: ['notAField'] })
+
+// @ts-expect-error nested fields should be constrained to valid nested paths.
+serviceApi.getServiceTickets({ fields: ['company/notAField'] })
+
+// @ts-expect-error orderBy fields should be constrained to Ticket field paths.
+serviceApi.getServiceTickets({ orderBy: [{ field: 'notAField', direction: 'asc' }] })
+
+// @ts-expect-error orderBy direction should be constrained to asc or desc.
+serviceApi.getServiceTickets({ orderBy: [{ field: 'summary', direction: 'ascending' }] })

--- a/test/test-manage.mjs
+++ b/test/test-manage.mjs
@@ -48,4 +48,29 @@ describe('Manage', () => {
       })
     }
   })
+
+  describe('request params', () => {
+    it('serializes typed fields and orderBy arrays for Manage queries', async () => {
+      let requestArgs
+      cwm.instance = async (args) => {
+        requestArgs = args
+        return { data: [] }
+      }
+
+      await cwm.ServiceAPI.getServiceTickets({
+        fields: ['id', 'summary', 'company/id'],
+        orderBy: [
+          { field: 'company/id', direction: 'asc' },
+          { field: 'summary', direction: 'desc' },
+        ],
+        conditions: 'closedFlag = false',
+      })
+
+      assert.deepStrictEqual(requestArgs.params, {
+        fields: 'id,summary,company/id',
+        orderBy: 'company/id asc,summary desc',
+        conditions: 'closedFlag = false',
+      })
+    })
+  })
 })


### PR DESCRIPTION
# Changes

Adds typed `fields` and `orderBy` support for ConnectWise Manage query parameters.

- `CommonParameters` is now generic: `CommonParameters<T>`.
- `fields` now accepts an array of valid model field paths.
- `orderBy` now accepts typed `{ field, direction }` entries.
- Generated Manage API methods now infer the correct parameter type from their response model.
- Runtime request handling serializes the typed arrays into the comma-separated strings expected by ConnectWise Manage.
- Adds type tests and request serialization coverage.
- Exports package types through `package.json` `exports`.

Before:

```ts
await cwm.ServiceAPI.getServiceTickets({
  fields: 'id,summary,company/id',
  orderBy: 'company/id asc,summary desc',
})
```
After:
```ts
await cwm.ServiceAPI.getServiceTickets({
  fields: ['id', 'summary', 'company/id'],
  orderBy: [
    { field: 'company/id', direction: 'asc' },
    { field: 'summary', direction: 'desc' },
  ],
})

// Invalid fields are now caught by TypeScript:
await cwm.ServiceAPI.getServiceTickets({
  fields: ['notAField'], // TypeScript error
})

// Invalid sort directions are also caught:
await cwm.ServiceAPI.getServiceTickets({
  orderBy: [{ field: 'summary', direction: 'ascending' }], // TypeScript error
})
```

# Why
This makes Manage query parameters safer and easier to use.
Using raw strings for fields and orderBy allowed typos to compile and only fail at runtime. The new typed API gives autocomplete for valid fields, supports nested field paths like company/id, and validates sort directions as 'asc' | 'desc'.
The runtime behavior still sends the format ConnectWise expects:
```ts
{
  fields: ['id', 'summary', 'company/id'],
  orderBy: [
    { field: 'company/id', direction: 'asc' },
    { field: 'summary', direction: 'desc' },
  ],
}
```
is serialized to:
```ts
{
  fields: 'id,summary,company/id',
  orderBy: 'company/id asc,summary desc',
}
```
This improves developer experience without changing the underlying API contract.
